### PR TITLE
v2.3.9

### DIFF
--- a/src/container/services/RouterServiceProvider.ts
+++ b/src/container/services/RouterServiceProvider.ts
@@ -23,11 +23,6 @@ export default class RouterServiceProvider
         ControllerDir: ["container/controllers"],
         middleware: [],
         AuthRouteExceptions: [],
-        data: (): {} => {
-          return {
-            chasiVer: "2.3.5"
-          };
-        },
         mount: <RouterMountable[]>[
           {
             name: "engine",
@@ -35,8 +30,6 @@ export default class RouterServiceProvider
             exec: CompilerEngine.instance,
           },
         ],
-        before: (request, response) => {},
-        after: (request, response) => {},
         displayLog: 1,
       }),
       new Router(<RouterConfigInterface>{
@@ -53,17 +46,13 @@ export default class RouterServiceProvider
         ],
         data: (): {} => {
           return {
-            chasiVer: "2.3.5"
+            chasiVer: "2.3.9"
           };
         },
-        before: (request, response) => {
+        before: (request: any, response: any, data: any) => {
           try {
             response.set("Content-Type", "application/json")
-          } catch (e) {
-            console.log(e)
-          }
-        },
-        after: (request, response) => {
+          } catch (e) {}
         },
         displayLog: 1,
       }),

--- a/src/package/framework/Interfaces.ts
+++ b/src/package/framework/Interfaces.ts
@@ -158,14 +158,14 @@ export type RouteGroupProperty = {
    * before() will be emitted before
    * function/controller execution.
    */
-  before?: Function;
+  before?: (request?: any, response?: any, data?: any) => {};
 
   /** RouteGroup after event
    * after() will be emitted before
    * sending a response object 
    * to the client
    */
-  after?: Function;
+  after?: (request?: any, response?: any, data?: any) => {};
 };
 
 export type ExceptionProperty = {

--- a/src/package/framework/Router/Router.types.ts
+++ b/src/package/framework/Router/Router.types.ts
@@ -103,7 +103,7 @@ export type RouterConfigInterface = {
    * before a request is passed
    * into controller/handler function.
    */
-  before?: () => void;
+  before?: (request?: any, response?: any, data?: any) => void;
 
   /** ?after
    * @after [Router Hook] 
@@ -111,7 +111,7 @@ export type RouterConfigInterface = {
    * before a response 
    * is sent back.
    */
-  after?: () => void;
+  after?: (request?: any, response?: any, data?: any) => void;
 
   /** ?displayLog
    * [0] to disable router logs


### PR DESCRIPTION
### Chasi 2.3.9
**v2.3.8 >> v2.3.9**

_- added new test feature env [vitest]
- added Error handling feature, when thrown a class that extends the Error class with a status, respond will automatically set statusCode to the status, and message.
- replaced (__dirname) to (___location) in globals 
- added Logging features [process.env[“Log_Level”]. 0 to disable logwriter, [>=1] to enable
- automatically detect .mw files inside middlewares.
- compiler engines will automatically be disabled on process.env[testMode] enabled.
- automatically wrap error message with {message: <error.message>} if Response.header is set to “application/json”
- ./test and ./src/errors directories will be added in the main repo._
