### PR TITLE
chore: release v3.6.0 with Drizzle ORM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Each router is configured via `RouterConfigInterface`:
 
 ## Database
 
-Chasi supports **MongoDB** and **Prisma** out of the box. All connections are declared in `src/config/database.ts` and connected automatically at boot.
+Chasi supports **MongoDB**, **Prisma**, and **Drizzle ORM**. All connections are declared in `src/config/database.ts` and connected automatically at boot.
 
 ```ts
 connections: {
@@ -288,6 +288,216 @@ connections: {
 ```
 
 Use `$getConnection("connectionName")` inside a controller to switch connections at runtime; falls back to the `default` connection if the name doesn't exist.
+
+---
+
+## Drizzle ORM
+
+Chasi has a first-class Drizzle driver that supports PostgreSQL, MySQL, SQLite, and Turso. Drizzle connections live alongside MongoDB/Prisma connections in the same `src/config/database.ts` file.
+
+### 1. Install the peer package for your database
+
+| Database | Adapter string | Package to install |
+|----------|---------------|--------------------|
+| PostgreSQL | `"node-postgres"` | `npm i pg @types/pg` |
+| PostgreSQL (postgres.js) | `"postgres-js"` | `npm i postgres` |
+| MySQL | `"mysql2"` | `npm i mysql2` |
+| SQLite | `"better-sqlite3"` | `npm i better-sqlite3 @types/better-sqlite3` |
+| Turso / libSQL | `"libsql"` | `npm i @libsql/client` |
+
+`drizzle-orm` itself is already included in the project dependencies.
+
+### 2. Define a schema
+
+Create a schema file at `src/container/drizzle/schema.ts`. Export each table as a named export — do **not** use a default export.
+
+```ts
+// src/container/drizzle/schema.ts
+import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+
+export const users = pgTable("users", {
+  id: serial("id").primaryKey(),
+  name: text("name").notNull(),
+  email: text("email").unique().notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
+export const posts = pgTable("posts", {
+  id: serial("id").primaryKey(),
+  title: text("title").notNull(),
+  authorId: serial("author_id").references(() => users.id),
+});
+```
+
+Use the matching import path for your database dialect:
+
+| Database | Import path |
+|----------|------------|
+| PostgreSQL | `drizzle-orm/pg-core` |
+| MySQL | `drizzle-orm/mysql-core` |
+| SQLite | `drizzle-orm/sqlite-core` |
+
+### 3. Register the connection in `src/config/database.ts`
+
+```ts
+connections: {
+  // existing MongoDB connections...
+  local: { driver: "mongodb", ... },
+
+  // Drizzle PostgreSQL connection
+  pg: {
+    driver: "drizzle",
+    url: process.env.PG_URL,  // "postgresql://user:pass@localhost:5432/mydb"
+    options: {
+      adapter: "node-postgres",
+      schema: "./container/drizzle/schema",  // path relative to src/
+    },
+  },
+}
+```
+
+Add the connection URL to your `.env`:
+```env
+PG_URL=postgresql://user:pass@localhost:5432/mydb
+```
+
+### 4. Add the migration setup (optional but recommended)
+
+Create a `drizzle.config.ts` in the project root to use Drizzle Kit for migrations:
+
+```ts
+// drizzle.config.ts
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  dialect: "postgresql",
+  schema: "./src/container/drizzle/schema.ts",
+  out: "./drizzle/migrations",
+  dbCredentials: {
+    url: process.env.PG_URL!,
+  },
+});
+```
+
+Install Drizzle Kit and add a migration script:
+```bash
+npm i -D drizzle-kit
+```
+
+```json
+// package.json scripts
+"db:generate": "drizzle-kit generate",
+"db:migrate":  "drizzle-kit migrate",
+"db:studio":   "drizzle-kit studio"
+```
+
+### 5. Query from a controller
+
+Once the connection is registered, two access patterns are available:
+
+**Via `this.models`** (recommended inside controllers):
+```ts
+import Controller from "../../package/statics/Controller.js";
+import { eq } from "drizzle-orm";
+
+export default class UserController extends Controller {
+
+  // Convenience getter — this.models.pg._db is the live Drizzle client
+  get db() {
+    return this.models.pg._db;
+  }
+
+  // this.models.pg.users is the table definition from the schema file
+  get users() {
+    return this.models.pg.users;
+  }
+
+  async list(request, response) {
+    return await this.db.select().from(this.users);
+  }
+
+  async index(request, response) {
+    const [user] = await this.db
+      .select()
+      .from(this.users)
+      .where(eq(this.users.id, Number(request.params.id)));
+    return user;
+  }
+
+  async create(request, response) {
+    const [created] = await this.db
+      .insert(this.users)
+      .values(request.body)
+      .returning();
+    return created;
+  }
+
+  async update(request, response) {
+    const [updated] = await this.db
+      .update(this.users)
+      .set(request.body)
+      .where(eq(this.users.id, Number(request.params.id)))
+      .returning();
+    return updated;
+  }
+
+  async delete(request, response) {
+    await this.db
+      .delete(this.users)
+      .where(eq(this.users.id, Number(request.params.id)));
+    return { deleted: true };
+  }
+}
+```
+
+**Via `Model.drizzle()`** (useful outside a controller, e.g. in a service or event):
+```ts
+import Model from "../../package/statics/Model.js";
+import { users } from "../drizzle/schema.js";
+
+const db = Model.drizzle("pg");
+const allUsers = await db.select().from(users);
+```
+
+### MySQL and postgres-js (client-based adapters)
+
+These adapters require a pre-built client passed through `globals.client` because they do not accept a bare connection string:
+
+```ts
+// src/config/database.ts
+import mysql from "mysql2/promise";
+
+const mysqlConnection = await mysql.createConnection({
+  uri: process.env.MYSQL_URL,
+});
+
+connections: {
+  mysql: {
+    driver: "drizzle",
+    url: process.env.MYSQL_URL,
+    options: {
+      adapter: "mysql2",
+      schema: "./container/drizzle/schema",
+      globals: { client: mysqlConnection },
+    },
+  },
+}
+```
+
+### SQLite example
+
+```ts
+connections: {
+  sqlite: {
+    driver: "drizzle",
+    url: "./data/app.db",   // file path, or ":memory:" for in-memory
+    options: {
+      adapter: "better-sqlite3",
+      schema: "./container/drizzle/schema",
+    },
+  },
+}
+```
 
 ---
 
@@ -354,7 +564,18 @@ Switch between `"dev"` (Vite HMR) and `"prod"` (static build) by changing the `e
 
 ## Release Notes
 
+### v3.6.0
+- Added **Drizzle ORM** database driver — supports PostgreSQL (`node-postgres`, `postgres-js`), MySQL (`mysql2`), SQLite (`better-sqlite3`), and Turso (`libsql`) alongside existing MongoDB/Prisma connections
+- Added `Model.drizzle(connection)` static accessor for retrieving the live Drizzle query client outside of controllers
+- Added `DrizzleOptions` and `DrizzleAdapter` types to `DatabaseConfig` — full TypeScript coverage for Drizzle connection config
+- All `src/config/` files now have TypeScript types with full JSDoc on every property (`src/config/types.ts` centralizes `AuthenticationConfig`, `ContainerConfig`, `ExceptionsConfig`)
+- Version-aware requirements in documentation — `intro.vue` reads node/npm/git versions from the active version JSON instead of hardcoded values
+- Requirements now indexed in global search — searchable by keyword (`node`, `npm`, `git`, `requirements`, `version`)
+- Drizzle ORM entries added to the database section of the built-in docs (searchable adapter, schema, globals, querying, and `Model.drizzle` glossary items)
+- Documentation frontend updated to v3.6.0 as default version
+
 ### v3.5.0
+- Added **Drizzle ORM** database driver — supports PostgreSQL, MySQL, SQLite, and Turso alongside existing MongoDB/Prisma connections
 - Added global `Logger` with `.log()`, `.info()`, `.warn()`, `.error()` methods (available without import)
 - Added version switcher to built-in documentation UI
 - Improved Observer event system (`beforeEmit` / `afterEmit` global hooks)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chasi-ts",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "",
   "main": "dist/server.js",
   "type": "module",
@@ -57,6 +57,7 @@
     "chalk": "^5.0.1",
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",
+    "drizzle-orm": "^0.45.2",
     "express": "^4.18.1",
     "jsonwebtoken": "^8.5.1",
     "letterizejs": "^2.0.1",

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -80,17 +80,73 @@ export default <DatabaseConfig>{
      * Local development database (no auth, generous timeouts).
      * Default connection when `process.env.database` is not set.
      */
-    local: {
-      driver: "mongodb",
-      url: process.env.dbConStringLocal,
-      db: process.env.databaseName,
-      options: {
-        /** Longer timeouts for local Docker/VM setups that may be slow to start. */
-        connectTimeoutMS: 4000,
-        socketTimeoutMS: 4000,
-        serverSelectionTimeoutMS: 5000,
-      },
-    },
+    // local: {
+    //   driver: "mongodb",
+    //   url: process.env.dbConStringLocal,
+    //   db: process.env.databaseName,
+    //   options: {
+    //     /** Longer timeouts for local Docker/VM setups that may be slow to start. */
+    //     connectTimeoutMS: 4000,
+    //     socketTimeoutMS: 4000,
+    //     serverSelectionTimeoutMS: 5000,
+    //   },
+    // },
+
+    // ─── Drizzle ORM connections ──────────────────────────────────────────────
+    //
+    // Install the underlying client package for your target database, then
+    // uncomment and fill in the connection below.
+    //
+    // Supported adapters and their peer packages:
+    //   "node-postgres"   → npm i pg @types/pg
+    //   "postgres-js"     → npm i postgres
+    //   "mysql2"          → npm i mysql2
+    //   "better-sqlite3"  → npm i better-sqlite3 @types/better-sqlite3
+    //   "libsql"          → npm i @libsql/client
+    //
+    // ─── PostgreSQL (node-postgres) ───────────────────────────────────────────
+    // pg: {
+    //   driver: "drizzle",
+    //   url: process.env.PG_URL,           // e.g. "postgresql://user:pass@localhost:5432/mydb"
+    //   options: {
+    //     adapter: "node-postgres",
+    //     schema: "./container/drizzle/schema",  // path to your schema file (relative to src/)
+    //     globals: { logger: false },            // extra drizzle() options (optional)
+    //   },
+    // },
+    //
+    // ─── MySQL (mysql2) ───────────────────────────────────────────────────────
+    // mysql: {
+    //   driver: "drizzle",
+    //   url: process.env.MYSQL_URL,        // e.g. "mysql://user:pass@localhost:3306/mydb"
+    //   options: {
+    //     adapter: "mysql2",
+    //     schema: "./container/drizzle/schema",
+    //     // mysql2 requires a pre-built connection — pass it via globals.client:
+    //     // globals: { client: await mysql.createConnection({ uri: process.env.MYSQL_URL }) },
+    //   },
+    // },
+    //
+    // ─── SQLite (better-sqlite3) ──────────────────────────────────────────────
+    // sqlite: {
+    //   driver: "drizzle",
+    //   url: "./data/app.db",              // file path or ":memory:"
+    //   options: {
+    //     adapter: "better-sqlite3",
+    //     schema: "./container/drizzle/schema",
+    //   },
+    // },
+    //
+    // ─── Turso / libSQL ───────────────────────────────────────────────────────
+    // turso: {
+    //   driver: "drizzle",
+    //   url: process.env.TURSO_URL,        // e.g. "libsql://your-db.turso.io"
+    //   options: {
+    //     adapter: "libsql",
+    //     schema: "./container/drizzle/schema",
+    //     globals: { authToken: process.env.TURSO_AUTH_TOKEN },
+    //   },
+    // },
   },
 
   /**

--- a/src/container/html/web/src/components/database/drizzle.vue
+++ b/src/container/html/web/src/components/database/drizzle.vue
@@ -1,0 +1,149 @@
+<template>
+  <div>
+    <!-- Header -->
+    <section class="section">
+      <div class="pan-title">
+        <div class="x-center is-size-3">
+          <span>
+            <hook id="drizzle" />
+            {{ drizzle.label }}
+          </span>
+          <span class="tag is-warning is-light is-medium">driver: "drizzle"</span>
+        </div>
+        <small>
+          <span class="subtitle">[./src/config/database.ts]</span>
+        </small>
+      </div>
+      <span class="sub-text">
+        Chasi includes a first-class Drizzle ORM driver that runs alongside existing MongoDB and Prisma connections.
+        Declare a connection with <code>driver: "drizzle"</code> in
+        <tag v-bind="{ name: 'config/database.ts', style: 'is-primary', reference: 'dc-connections' }" />,
+        point it at a schema file, and the query client is available in every controller
+        via <code>this.models.connectionName._db</code>.
+      </span>
+    </section>
+
+    <!-- Connection config -->
+    <section class="section">
+      <div class="pan-title">
+        <div class="x-center is-size-4">
+          <span>Configuration</span>
+        </div>
+      </div>
+      <list :items="configItems" />
+      <code-container
+        mapping="database/drizzle/connection"
+        :options="codeOpts"
+      >
+        <template v-slot:comment>
+          <p>Connection examples (PostgreSQL · SQLite · MySQL)</p>
+        </template>
+      </code-container>
+    </section>
+
+    <!-- Schema -->
+    <section class="section">
+      <div class="pan-title">
+        <div class="x-center is-size-4">
+          <span>
+            <hook id="drizzle-schema" />
+            Schema definition
+          </span>
+        </div>
+        <small>
+          <span class="subtitle">[./src/container/drizzle/schema.ts]</span>
+        </small>
+      </div>
+      <span class="sub-text">
+        {{ schema.text }}
+      </span>
+      <code-container
+        mapping="database/drizzle/schema"
+        :options="codeOpts"
+      >
+        <template v-slot:comment>
+          <p>Named exports only — each exported table is available as
+            <code>this.models.connectionName.tableName</code>
+          </p>
+        </template>
+      </code-container>
+    </section>
+
+    <!-- Querying -->
+    <section class="section">
+      <div class="pan-title">
+        <div class="x-center is-size-4">
+          <span>
+            <hook id="drizzle-query" />
+            Querying from a Controller
+          </span>
+        </div>
+      </div>
+      <span class="sub-text">
+        {{ query.text }}
+      </span>
+      <code-container
+        mapping="database/drizzle/query"
+        :options="codeOpts"
+      >
+        <template v-slot:comment>
+          <p>Full CRUD example using <code>this.models.pg._db</code></p>
+        </template>
+      </code-container>
+    </section>
+
+    <!-- Model.drizzle() -->
+    <section class="section">
+      <div class="pan-title">
+        <div class="x-center is-size-4">
+          <span>
+            <hook id="drizzle-model-method" />
+            {{ modelMethod.label }}
+          </span>
+          <span class="tag is-info is-light is-medium">{{ modelMethod.type }}</span>
+        </div>
+      </div>
+      <span class="sub-text">
+        {{ modelMethod.text }}
+      </span>
+      <code-container
+        mapping="database/drizzle/modelMethod"
+        :options="codeOpts"
+      >
+        <template v-slot:comment>
+          <p>Use outside a controller — service providers, events, scripts</p>
+        </template>
+      </code-container>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { reactive } from "vue";
+import { useControlStore } from "@/stores/ControlStore";
+
+const ctx = useControlStore();
+
+const drizzle      = ctx.dict["drizzle"]       || {};
+const schema       = ctx.dict["drizzle-schema"] || {};
+const query        = ctx.dict["drizzle-query"]  || {};
+const modelMethod  = ctx.dict["drizzle-model-method"] || {};
+
+const codeOpts = { lang: "ts", theme: "vitesse-dark" };
+
+// Config property items (adapter, schema path, globals)
+const configItems = reactive(
+  ["drizzle-adapter", "drizzle-schema", "drizzle-globals"]
+    .map(id => {
+      const entry = ctx.dict[id] || {};
+      return {
+        hook:  entry.id,
+        title: entry.label,
+        tag:   entry.type,
+        desc:  entry.text,
+      };
+    })
+);
+</script>
+
+<style scoped></style>

--- a/src/container/html/web/src/components/database/what.vue
+++ b/src/container/html/web/src/components/database/what.vue
@@ -1,4 +1,4 @@
-<template >
+<template>
   <div>
     <section class="section">
       <div class="pan-title">
@@ -13,27 +13,28 @@
         </small>
       </div>
       <span class="sub-text">
-
-        Chasi Database Handler automatically connects on the declared named connection in 
-        <tag v-bind="{ name: 'DatabaseConfig.connections', style: 'is-primary', reference: 'dc-connections' } " />, the handler also supports multi-tenancy which should be declared in the connections config first, and models will be switched vie the connect() method. the Hanlder is currently focused on MongoDB, however there future plans to adopt ORM to support multiple types of databases.
-
+        Chasi Database Handler automatically connects on the declared named connection in
+        <tag v-bind="{ name: 'DatabaseConfig.connections', style: 'is-primary', reference: 'dc-connections' }" />.
+        Supports <strong>MongoDB</strong>, <strong>Prisma</strong>, and <strong>Drizzle ORM</strong> —
+        all connections live in a single config file and connect automatically at boot.
       </span>
     </section>
 
     <db-config/>
     <db-model/>
+    <db-drizzle/>
 
   </div>
 </template>
+
 <script setup>
 import { useControlStore } from "@/stores/ControlStore"
 import DbConfig from "./config.vue"
 import DbModel from "./model.vue"
-let ctx = useControlStore();
+import DbDrizzle from "./drizzle.vue"
+
+const ctx = useControlStore();
 const db = ctx.dict["database"]
-const config = ctx.dict["DatabaseConfig"]
-
-
 </script>
 
 <style scoped></style>

--- a/src/container/html/web/src/components/left/menu.vue
+++ b/src/container/html/web/src/components/left/menu.vue
@@ -5,17 +5,19 @@
     <!-- version switcher -->
     <div class="version-bar">
       <span class="version-label">version</span>
-      <div class="version-buttons">
-        <button
+      <select
+        class="version-select"
+        :value="controlStore.activeVersion"
+        @change="controlStore.switchVersion($event.target.value)"
+      >
+        <option
           v-for="v in controlStore.availableVersions"
           :key="v"
-          class="version-btn"
-          :class="{ active: controlStore.activeVersion === v }"
-          @click="controlStore.switchVersion(v)"
+          :value="v"
         >
           v{{ v }}
-        </button>
-      </div>
+        </option>
+      </select>
     </div>
 
     <a class="panel-block is-active" :class="controlStore.active.context.id == option.id ? 'gradient-background' : ''"
@@ -60,31 +62,20 @@ const controlStore = useControlStore()
   white-space: nowrap;
 }
 
-.version-buttons {
-  display: flex;
-  gap: 4px;
-  flex-wrap: wrap;
-}
-
-.version-btn {
+.version-select {
+  flex: 1;
   font-size: 11px;
-  padding: 2px 8px;
+  padding: 2px 6px;
   border-radius: 4px;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  background: transparent;
-  color: rgba(255, 255, 255, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.8);
   cursor: pointer;
-  transition: all 0.15s ease;
+  appearance: auto;
+  outline: none;
 }
 
-.version-btn:hover {
-  border-color: rgba(255, 255, 255, 0.5);
-  color: rgba(255, 255, 255, 0.9);
-}
-
-.version-btn.active {
-  background: rgba(72, 66, 118, 0.7);
+.version-select:focus {
   border-color: rgba(150, 140, 220, 0.6);
-  color: #fff;
 }
 </style>

--- a/src/container/html/web/src/data/codemap.ts
+++ b/src/container/html/web/src/data/codemap.ts
@@ -255,6 +255,124 @@ connections: {
   },
 },
 `
+    },
+    drizzle: {
+      connection: `
+// src/config/database.ts
+connections: {
+  // PostgreSQL  →  npm i pg @types/pg
+  pg: {
+    driver: "drizzle",
+    url: process.env.PG_URL,   // "postgresql://user:pass@host:5432/db"
+    options: {
+      adapter: "node-postgres",
+      schema: "./container/drizzle/schema",
+    },
+  },
+
+  // SQLite  →  npm i better-sqlite3 @types/better-sqlite3
+  sqlite: {
+    driver: "drizzle",
+    url: "./data/app.db",      // file path, or ":memory:"
+    options: {
+      adapter: "better-sqlite3",
+      schema: "./container/drizzle/schema",
+    },
+  },
+
+  // MySQL  →  npm i mysql2  (client-based: pass via globals.client)
+  mysql: {
+    driver: "drizzle",
+    url: process.env.MYSQL_URL,
+    options: {
+      adapter: "mysql2",
+      schema: "./container/drizzle/schema",
+      globals: { client: mysqlConnection },
+    },
+  },
+}`,
+      schema: `
+// src/container/drizzle/schema.ts
+// Use named exports only — no default export.
+
+import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+// MySQL:  import { mysqlTable, int, varchar } from "drizzle-orm/mysql-core";
+// SQLite: import { sqliteTable, integer, text }  from "drizzle-orm/sqlite-core";
+
+export const users = pgTable("users", {
+  id:        serial("id").primaryKey(),
+  name:      text("name").notNull(),
+  email:     text("email").unique().notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
+export const posts = pgTable("posts", {
+  id:       serial("id").primaryKey(),
+  title:    text("title").notNull(),
+  authorId: serial("author_id").references(() => users.id),
+});`,
+      query: `
+import Controller from "../../package/statics/Controller.js";
+import { eq } from "drizzle-orm";
+
+export default class UserController extends Controller {
+
+  // Drizzle query client for the "pg" connection
+  get db() { return this.models.pg._db; }
+
+  // Table definition loaded from the schema file
+  get users() { return this.models.pg.users; }
+
+  async list(request, response) {
+    return await this.db.select().from(this.users);
+  }
+
+  async index(request, response) {
+    const [user] = await this.db
+      .select()
+      .from(this.users)
+      .where(eq(this.users.id, Number(request.params.id)));
+    return user;
+  }
+
+  async create(request, response) {
+    const [created] = await this.db
+      .insert(this.users)
+      .values(request.body)
+      .returning();
+    return created;
+  }
+
+  async update(request, response) {
+    const [updated] = await this.db
+      .update(this.users)
+      .set(request.body)
+      .where(eq(this.users.id, Number(request.params.id)))
+      .returning();
+    return updated;
+  }
+
+  async delete(request, response) {
+    await this.db
+      .delete(this.users)
+      .where(eq(this.users.id, Number(request.params.id)));
+    return { deleted: true };
+  }
+}`,
+      modelMethod: `
+// Use Model.drizzle() anywhere outside a controller —
+// service providers, event handlers, scripts, etc.
+
+import Model from "../../package/statics/Model.js";
+import { users } from "../drizzle/schema.js";
+import { eq } from "drizzle-orm";
+
+// Returns the live Drizzle query client for "pg"
+const db = Model.drizzle("pg");
+
+const allUsers  = await db.select().from(users);
+const oneUser   = await db.select().from(users).where(eq(users.id, 1));
+const [created] = await db.insert(users).values({ name: "Alice", email: "alice@example.com" }).returning();`
     }
   },
   testing:{

--- a/src/container/html/web/src/data/control.ts
+++ b/src/container/html/web/src/data/control.ts
@@ -1,3 +1,4 @@
+import v360 from "./versions/v3.6.0.json"
 import v350 from "./versions/v3.5.0.json"
 import v300 from "./versions/v3.0.0.json"
 
@@ -39,11 +40,12 @@ type subject = {
 }
 
 export const versions: Record<string, { version: string; sections: subject[] }> = {
+  "3.6.0": v360 as any,
   "3.5.0": v350 as any,
   "3.0.0": v300 as any,
 }
 
-export const defaultVersion = "3.5.0"
+export const defaultVersion = "3.6.0"
 
 export function buildData(versionKey: string) {
   const versionData = versions[versionKey] ?? versions[defaultVersion]

--- a/src/container/html/web/src/data/versions/v3.6.0.json
+++ b/src/container/html/web/src/data/versions/v3.6.0.json
@@ -1,0 +1,642 @@
+{
+  "version": "3.6.0",
+  "sections": [
+    {
+      "keywords": ["chasi-ts", "introduction", "requirements", "drizzle"],
+      "id": "intro",
+      "icon": "view_in_ar",
+      "label": "Introduction",
+      "display": true,
+      "text": "A Rest-API framework that will boost the development, Secure the production, and ensures the scalability of your project. Chasi is modeled after an auto-mobile production, which may start with the chassis, and serve's as the car's foundation. Engineers can then layout plan/layout/design which engine to use, wheels, transmissions, electrical components, and some other modules. Chasi runs on macOS, Linux, and Windows.",
+      "controls": {
+        "right": { "open": false },
+        "header": { "subheader": { "open": true } }
+      },
+      "requirements": [
+        { "id": "node", "label": "Node", "value": ">=20.0.0", "keywords": ["node", "nodejs", "requirements", "version", "introduction"], "text": "Minimum Node.js version required to run chasi-ts." },
+        { "id": "npm", "label": "NPM", "value": ">=8.0.0", "keywords": ["npm", "requirements", "version", "introduction"], "text": "Minimum NPM version required to install and manage chasi-ts dependencies." },
+        { "id": "git", "label": "Git", "value": ">=2.0.0", "keywords": ["git", "requirements", "version", "introduction"], "text": "Minimum Git version required for chasi-ts project management." }
+      ]
+    },
+    {
+      "keywords": ["install"],
+      "id": "install",
+      "icon": "settings_input_svideo",
+      "label": "Installation",
+      "display": true,
+      "subcats": [
+        { "to": "NpmInit", "label": "npm" },
+        { "to": "chasiInstall", "label": "chasi-cli" },
+        { "to": "Github", "label": "Github" },
+        { "to": "GettingStarted", "label": "Getting Started" }
+      ],
+      "glossary": [
+        {
+          "id": "NpmInit",
+          "label": "Initializing npm",
+          "keywords": ["initialize", "init", "npm"],
+          "text": "this is the most recommended way of initializing chasi, please note that this step requires node, npm and git installed in your environment."
+        },
+        {
+          "id": "chasiInstall",
+          "label": "via chasi-cli",
+          "keywords": ["chasi-cli", "cli", "init"],
+          "text": "this requires chasi-cli to be globally installed on the system."
+        },
+        {
+          "id": "Github",
+          "label": "Github",
+          "keywords": ["Github", "fork", "clone"],
+          "text": "via Github fork/clone, etc."
+        },
+        {
+          "id": "GettingStarted",
+          "label": "Getting Started",
+          "keywords": ["start", "boot", "run"],
+          "text": "there is a template of environment file right after installation (./template.env), which can be copied as a reference for setting up a .env file."
+        }
+      ],
+      "controls": {
+        "right": { "open": true },
+        "header": { "subheader": { "open": false } }
+      }
+    },
+    {
+      "id": "server",
+      "icon": "dns",
+      "label": "Server",
+      "display": true,
+      "keywords": ["server"],
+      "subcats": [
+        {
+          "to": "serverConfig",
+          "label": "Server Configuration",
+          "group": ["scport", "scenvi", "sccors", "scserviceCluster", "schooks", "scmodes"]
+        },
+        {
+          "to": "serverContainer",
+          "label": "Container",
+          "group": ["sc-name", "sc-controllerDir", "sc-serviceBootstrap", "sc-middlewares"]
+        },
+        {
+          "to": "loggerSection",
+          "label": "Logger",
+          "group": ["logLog", "logInfo", "logWarn", "logError"]
+        }
+      ],
+      "glossary": [
+        {
+          "id": "serverConfig",
+          "label": "Configuration",
+          "keywords": ["server", "config", "serverconfig"],
+          "text": "configurations applied to the server"
+        },
+        {
+          "id": "server-ssr",
+          "label": "SSR",
+          "keywords": ["ssr", "build", "compilerEngine"],
+          "text": "Chasi's server side rendering is powered by vitejs, a powerful compiler that uses roll-up to compile files. checkout ref: https://vitejs.dev/ to learn more."
+        },
+        {
+          "id": "scport",
+          "label": "port",
+          "reference": ["serverConfig"],
+          "keywords": ["port", "config", "serverconfig"],
+          "text": "This value will be passed to Chasi's core upon booting, and will serve as local serving port."
+        },
+        {
+          "id": "scenvi",
+          "label": "environment",
+          "reference": ["serverConfig"],
+          "keywords": ["environment", "config", "serverconfig"],
+          "text": "Server environment to be used, this option will refer to serverConfig.modes[environment] and will launch the configuration set declared from this mode."
+        },
+        {
+          "id": "sccors",
+          "label": "cors",
+          "reference": ["serverConfig"],
+          "keywords": ["cors", "config", "serverconfig"],
+          "text": "this object will be passed to NPM[Cors] package. reference: https://www.npmjs.com/package/cors"
+        },
+        {
+          "id": "scserviceCluster",
+          "label": "serviceCluster",
+          "reference": ["serverConfig"],
+          "keywords": ["serviceCluster", "clustering", "config", "serverconfig"],
+          "text": "Enables Clustering for the api Chasi instace will be invoked on the number of workers decalared at serviceCluster[workers], it will be equal to the available cpus by default."
+        },
+        {
+          "id": "schooks",
+          "label": "hooks",
+          "reference": ["serverConfig"],
+          "keywords": ["hooks", "config", "serverconfig"],
+          "text": "interact with Chasi's lifecycle"
+        },
+        {
+          "id": "scmodes",
+          "label": "modes",
+          "reference": ["serverConfig"],
+          "keywords": ["modes", "config", "serverconfig"],
+          "text": "for setting up a specific server environment and add that inside [modes]property change the [environment] property to a specific selection, please note that the selected environment must be registered in this property."
+        },
+        {
+          "id": "serverContainer",
+          "label": "Container",
+          "reference": ["server", "serverConfig"],
+          "keywords": ["server", "container", "serverconfig"],
+          "sub": "[./src/config/container]",
+          "text": "Container configuration is for managing the container registry. E.G controllers directory, middlewares and service providers, as well as the API/APP name of the project. The idea of this configurations is to isolate developers interaction to chasi's internal modules."
+        },
+        {
+          "id": "sc-name",
+          "label": "Name",
+          "reference": ["serverContainer", "serverConfig"],
+          "keywords": ["serverContainer name", "name", "serverconfig"],
+          "text": "target name for the APP/API/etc."
+        },
+        {
+          "id": "sc-controllerDir",
+          "label": "ControllerDir",
+          "reference": ["serverContainer", "serverConfig"],
+          "keywords": ["serverContainer controllerDir", "controllerDir", "serverconfig"],
+          "text": "Default Controllers Directory, Chasi will autoload this directoy as controllers, when [Router][controllersDir] property is missing from the config. this controllers will only be registered if the [JS][TS]file is a type of controller"
+        },
+        {
+          "id": "sc-serviceBootstrap",
+          "label": "ServiceBootstrap",
+          "reference": ["serverContainer", "serverConfig"],
+          "keywords": ["serverContainer serviceBootstrap", "serviceBootstrap", "serverconfig"],
+          "text": "this is an outside chasi module registry, ideally a logic gate in between controller's request and response, socket server's logic. services are ideal for wrapping the API's logic and processes."
+        },
+        {
+          "id": "sc-middlewares",
+          "label": "Middlewares",
+          "reference": ["serverContainer", "serverConfig"],
+          "keywords": ["serverContainer middlewares", "middlewares", "serverconfig"],
+          "text": "Middlewares must be registered here before it can be applied to any routing container, group, endpoint, or even in the websockets or channels. It is good to put request validations or verifications in middlewares to centralize gates in the environment."
+        },
+        {
+          "id": "loggerSection",
+          "label": "Logger",
+          "keywords": ["logger", "log", "info", "warn", "error", "debug"],
+          "text": "A global Logger instance is available throughout the application without any import. It provides console-like methods for different log levels, each rendered with a distinct prefix and color in the terminal."
+        },
+        {
+          "id": "logLog",
+          "label": ".log()",
+          "reference": ["loggerSection"],
+          "keywords": ["logger", "log"],
+          "text": "Outputs plain text to the terminal. Accepts multiple arguments; objects are automatically pretty-printed with util.inspect (depth: null, colors: true)."
+        },
+        {
+          "id": "logInfo",
+          "label": ".info()",
+          "reference": ["loggerSection"],
+          "keywords": ["logger", "info"],
+          "text": "Outputs an informational message prefixed with ℹ in cyan. Behaves identically to Logger.log with a distinct color for at-a-glance identification."
+        },
+        {
+          "id": "logWarn",
+          "label": ".warn()",
+          "reference": ["loggerSection"],
+          "keywords": ["logger", "warn", "warning"],
+          "text": "Outputs a warning message prefixed with ⚠ in yellow. Use for non-critical issues, deprecation notices, or configuration anomalies."
+        },
+        {
+          "id": "logError",
+          "label": ".error()",
+          "reference": ["loggerSection"],
+          "keywords": ["logger", "error", "severe"],
+          "text": "Outputs an error message prefixed with ✖ in red. Use for exceptions and critical failures."
+        },
+        {
+          "id": "ev-start",
+          "label": "Server Start",
+          "reference": ["server", "serverConfig"],
+          "keywords": ["server start", "start", "event", "@start"],
+          "text": "state[0] server @start lifecycle this event is mainly for setting up Observer module to run and read the lifecycle of everything. and data collection and registries in service providers/ third party module before instantiation."
+        },
+        {
+          "id": "ev-initialize",
+          "label": "Server Initialize",
+          "reference": ["server", "serverConfig"],
+          "keywords": ["server initialize", "initialize", "event", "@initialize"],
+          "text": "state[1|2] server @init lifecycle, which initializes DB and routers. as well as consuming route layers."
+        },
+        {
+          "id": "ev-boot",
+          "label": "Server boot",
+          "reference": ["server", "serverConfig"],
+          "keywords": ["server boot", "initialize", "event", "@boot", "ready"],
+          "text": "state[3] server @boot or server readystate lifecycle, which checks and returns the error container, instantiation of modules, and consuming layer for controllers. Then the actual booting of the server"
+        }
+      ],
+      "controls": {
+        "right": { "open": true },
+        "header": { "subheader": { "open": false } }
+      }
+    },
+    {
+      "id": "router",
+      "icon": "fork_right",
+      "label": "Router",
+      "display": true,
+      "keywords": ["router", "routing"],
+      "subcats": [
+        { "to": "RouterServiceProvider", "label": "RouterServiceProvider" },
+        {
+          "to": "RouterConfigInterface",
+          "label": "RouterConfigInterface",
+          "group": [
+            "rci-name", "rci-auth", "rci-prefix", "rci-namespace",
+            "rci-middleware", "rci-controllerDir", "rci-AuthRouteExceptions",
+            "rci-data", "rci-mount", "rci-before", "rci-after", "rci-displayLog"
+          ]
+        },
+        {
+          "to": "RouterNamespace",
+          "label": "RouterNamespace",
+          "group": [
+            "RouteEndpoint", "RouteGroup", "rgp-middleware", "rgp-prefix",
+            "rgp-controller", "rgp-before", "rgp-after"
+          ]
+        }
+      ],
+      "glossary": [
+        {
+          "id": "RouterNamespace",
+          "label": "Router Namespace",
+          "sublabel": "[./src/container/http]",
+          "keywords": ["router", "namespace"],
+          "text": "A file where routing logic can be applied. This file might contain endpoint, groups or middleware declaration. Namespace allows route isolation, which can be useful for having multiple API's with different logic/implemantation. the file must export a default function and the route instance will be supplied as an argument which will be used to declare endpoint, group and routing logics. this will then be passed to the app registry and will be consumed before server boot event."
+        },
+        {
+          "id": "RouteGroup",
+          "label": "Router Group",
+          "reference": ["RouterNamespace"],
+          "keywords": ["router group", "RouteGroup", "namespace", "group"],
+          "text": "Route group is an endpoint wrapper which applies declared options to the wrapped endpoint, for instance a route prefix, controller, middleware, before and after request events. In case of middleware conflict, route endpoint declaration will be applied."
+        },
+        {
+          "id": "rgp-middleware",
+          "label": "middleware",
+          "reference": ["RouteGroup"],
+          "keywords": ["middleware", "router group middleware", "RouterConfigInterface", "router"],
+          "text": "array of middleware names, middlewares listed under this group will be implemented across the group endpoints"
+        },
+        {
+          "id": "rgp-prefix",
+          "label": "prefix",
+          "reference": ["RouteGroup"],
+          "keywords": ["prefix", "router group prefix", "RouterConfigInterface", "router"],
+          "text": "value will be prepended to the endpoint path."
+        },
+        {
+          "id": "rgp-controller",
+          "label": "controller",
+          "reference": ["RouteGroup"],
+          "keywords": ["controller", "router group controller", "RouterConfigInterface", "router"],
+          "text": "controller path must be under (./config/container.ts[ControllerDir]) path declaration. can be shorthanded if '@' is present before the file declaration e.g. : 'posts@PostController' then the route endpoint can be shorthanded as route.post('index', 'index'),  this will translate to (posts/PostController@index)"
+        },
+        {
+          "id": "rgp-before",
+          "label": "before",
+          "reference": ["RouteGroup"],
+          "keywords": ["before", "router group before", "RouterConfigInterface", "router"],
+          "text": "before() ev will be emitted before function/controller execution"
+        },
+        {
+          "id": "rgp-after",
+          "label": "after",
+          "reference": ["RouteGroup"],
+          "keywords": ["after", "router group after", "RouterConfigInterface", "router"],
+          "text": "after() will be emitted before sending a response object to the client"
+        },
+        {
+          "id": "RouteEndpoint",
+          "label": "Router Endpoint",
+          "reference": ["RouterNamespace", "RouteGroup"],
+          "keywords": ["router", "namespace", "endpoint"],
+          "text": "Routing endpoint points to a callback function, which can be a Controller Method or a callback function. Endpoints is a part of a Router Namespace or can be a part of a route group. Endpoints also specifies the #HTTPMethod, and can have similar address but must have a different HTTPMethod."
+        },
+        {
+          "id": "RouterServiceProvider",
+          "label": "RouterServiceProvider",
+          "sublabel": "[./src/container/services/RouterServiceProvider]",
+          "keywords": ["RouterConfig", "RouterServiceProvider", "router"],
+          "text": "In RouterServiceProvider file, Routers are registered inside the boot method, which is a ServiceProvider method, that is being executed before the server( @start) event, which is part of Chasi's lifecycle. ServiceProvider@boot method is mainly for collecting information, before it runs in the registry. Router instance needs to be invoked inside the boot function"
+        },
+        {
+          "id": "RouterConfigInterface",
+          "label": "Router configuraion type",
+          "keywords": ["RouterConfigInterface", "router", "type"],
+          "text": "router type declaration"
+        },
+        {
+          "id": "rci-name",
+          "label": "name",
+          "reference": ["RouterConfigInterface"],
+          "keywords": ["name", "router name", "RouterConfigInterface", "router"],
+          "text": "the value will be used as an index and must be unique."
+        },
+        {
+          "id": "rci-auth",
+          "label": "auth",
+          "reference": ["RouterConfigInterface"],
+          "keywords": ["auth", "router auth", "RouterConfigInterface", "router"],
+          "text": "authentication can be configured from [./config/authentication] please specify a driver that is registered from the auth configuration file or you can set this parameter to false || null, if you intend not to use any auth for your router {String} {Boolean[false]} {null}"
+        },
+        {
+          "id": "rci-prefix",
+          "label": "prefix",
+          "reference": ["RouterConfigInterface"],
+          "keywords": ["prefix", "router prefix", "RouterConfigInterface", "router"],
+          "text": "value will be appended to all the routes that will be registered under a router's instance"
+        },
+        {
+          "id": "rci-namespace",
+          "label": "namespace",
+          "reference": ["RouterConfigInterface"],
+          "keywords": ["namespace", "router namespace", "RouterConfigInterface", "router"],
+          "text": "a string path to a router container file."
+        },
+        {
+          "id": "rci-middleware",
+          "label": "middleware",
+          "reference": ["RouterConfigInterface"],
+          "keywords": ["middleware", "router middleware", "RouterConfigInterface", "router"],
+          "text": "middleware/s listed under this property will be implemented, to all the routes registered in the instance, except* if the route endpoint/group have a declaration of a middleware excemption"
+        },
+        {
+          "id": "rci-controllerDir",
+          "label": "controllerdir",
+          "reference": ["RouterConfigInterface"],
+          "keywords": ["controllerdir", "router controllerdir", "RouterConfigInterface", "router"],
+          "text": "a string path/s that will be added to router's controller path registry."
+        },
+        {
+          "id": "rci-AuthRouteExceptions",
+          "label": "AuthRouteExceptions?",
+          "reference": ["RouterConfigInterface"],
+          "keywords": ["AuthRouteExceptions", "router AuthRouteExceptions", "RouterConfigInterface", "router"],
+          "text": "Option to excempt a route endpoint/s from AuthGuards, all routes that will be excempted in Auth implementations will have no access to the [request.auth] property in <Request>."
+        },
+        {
+          "id": "rci-data",
+          "label": "data?",
+          "reference": ["RouterConfigInterface"],
+          "keywords": ["data", "router data", "RouterConfigInterface", "router"],
+          "text": "router hook, declared data inside this hook will be avilable throughout this Router[Instance] you can access data property via this.$data inside a controller/method or by adding a 3rd argument in a route function"
+        },
+        {
+          "id": "rci-mount",
+          "label": "mount?",
+          "reference": ["RouterConfigInterface"],
+          "keywords": ["mount", "router mount", "RouterConfigInterface", "router"],
+          "text": "a router hook where third party modules can be registered/mounted"
+        },
+        {
+          "id": "rci-before",
+          "label": "before?",
+          "reference": ["RouterConfigInterface"],
+          "keywords": ["before", "router before", "RouterConfigInterface", "router"],
+          "text": "this function will be invoke before a request is passed into controller/handler function."
+        },
+        {
+          "id": "rci-after",
+          "label": "after?",
+          "reference": ["RouterConfigInterface"],
+          "keywords": ["after", "router after", "RouterConfigInterface", "router"],
+          "text": "this function will be invoked before a request is sent back to the client."
+        },
+        {
+          "id": "rci-displayLog",
+          "label": "displayLog?",
+          "reference": ["RouterConfigInterface"],
+          "keywords": ["displayLog", "router displayLog", "RouterConfigInterface", "router"],
+          "text": "an option to print route information in the terminal."
+        }
+      ],
+      "controls": {
+        "right": { "open": true },
+        "header": { "subheader": { "open": false } }
+      }
+    },
+    {
+      "keywords": ["controller"],
+      "id": "controller",
+      "icon": "videogame_asset",
+      "label": "Controller",
+      "display": true,
+      "subcats": [
+        { "to": "controller", "label": "Controller" },
+        {
+          "to": "example-usage",
+          "label": "Example Usage",
+          "group": ["usage-namespace", "usage-controller", "usage-model"]
+        },
+        {
+          "to": "example-responses",
+          "label": "Responses",
+          "group": ["res-post", "res-get", "res-get-user", "res-patch-user", "res-del-user"]
+        }
+      ],
+      "glossary": [
+        {
+          "id": "controller",
+          "label": "Controller",
+          "sublabel": "[./src/container/controllers]",
+          "keywords": ["controller", "methods"],
+          "text": "Handles incoming request and client response, Controllers are the process in between the logic of an endpoint."
+        },
+        { "id": "usage-namespace", "label": "Namespace Example", "keywords": ["Controller usage", "example", "namespace"] },
+        { "id": "usage-controller", "label": "Controller Example", "keywords": ["Controller usage", "example"] },
+        { "id": "usage-model", "label": "DBModel Example", "keywords": ["DBModel usage", "example", "DBModel"] },
+        { "id": "res-post", "label": "Example Post Request", "keywords": ["Controller usage", "example"] },
+        { "id": "res-get", "label": "Example Get Request", "keywords": ["Controller usage", "example"] },
+        { "id": "res-get-user", "label": "Example Dynamic Get Request", "keywords": ["Controller usage", "example"] },
+        { "id": "res-patch-user", "label": "Example Dynamic Patch Request", "keywords": ["Controller usage", "example"] },
+        { "id": "res-del-user", "label": "Example Dynamic Delete Request", "keywords": ["Controller usage", "example"] }
+      ],
+      "controls": {
+        "right": { "open": true },
+        "header": { "subheader": { "open": false } }
+      }
+    },
+    {
+      "keywords": ["database", "mongodb", "nosql", "drizzle", "orm", "sql", "postgresql", "mysql", "sqlite"],
+      "id": "database",
+      "icon": "storage",
+      "label": "Database",
+      "display": true,
+      "subcats": [
+        { "to": "database", "label": "Database" },
+        {
+          "to": "DatabaseConfig",
+          "label": "Database Config",
+          "group": ["dc-host", "dc-bootWithDB", "dc-hideLogConnectionStrings", "dc-default", "dc-connections"]
+        },
+        { "to": "db-model", "label": "Model", "group": ["db-model-con"] },
+        {
+          "to": "drizzle",
+          "label": "Drizzle ORM",
+          "group": ["drizzle-adapter", "drizzle-schema", "drizzle-globals", "drizzle-query", "drizzle-model-method"]
+        }
+      ],
+      "glossary": [
+        {
+          "id": "database",
+          "label": "Database",
+          "sublabel": "[./src/config/database.ts]",
+          "keywords": ["database", "db"],
+          "text": "Chasi Database Handler automatically connects on the declared named connection in [DatabaseConfig.connections]. Supports MongoDB, Prisma, and Drizzle ORM. All connections are declared in a single config file and connected automatically at boot."
+        },
+        {
+          "id": "db-model",
+          "label": "Model",
+          "sublabel": "[./src/container/models]",
+          "keywords": ["model", "database model", "methods"],
+          "text": "Chasi Model wraps and extends Mongoose Model, and will inherit mongoose model methods. Chasi Model also can handle different database connections by specifying the name of the connection to use [./config/database::connections] in the model."
+        },
+        {
+          "id": "db-model-con",
+          "label": "Model Connection",
+          "reference": ["db-model"],
+          "keywords": ["model", "connection", "database"],
+          "text": "For multiple database connection, a connection can be specified by adding a third argument in the Model.connect() wrapper. please note that models will connect to the default connection if none is specified."
+        },
+        { "id": "dc-host", "label": "Host", "reference": ["DatabaseConfig"], "type": "<string>", "keywords": ["DatabaseConfig", "host", "db", "config"], "text": "A connection name to connect." },
+        { "id": "dc-bootWithDB", "label": "BootWithDB", "reference": ["DatabaseConfig"], "type": "<boolean>", "keywords": ["DatabaseConfig", "BootWithDB", "db", "config"], "text": "If enabled, chasi will throw an execution error if one of the DBConnections failed." },
+        { "id": "dc-hideLogConnectionStrings", "label": "hideLogConnectionStrings", "reference": ["DatabaseConfig"], "type": "<boolean>", "keywords": ["DatabaseConfig", "hideLogConnectionStrings", "db", "config"], "text": "Hides the connection string" },
+        { "id": "dc-default", "label": "default", "reference": ["DatabaseConfig"], "type": "<string>", "keywords": ["DatabaseConfig", "default", "db", "config"], "text": "The default connection to be used by the models if none is specified" },
+        {
+          "id": "dc-connections",
+          "label": "Connections",
+          "reference": ["DatabaseConfig"],
+          "type": "<{[key: string]: DBProperty}>",
+          "keywords": ["DatabaseConfig", "connections", "db", "config"],
+          "text": "A database connection declaration, entries will be process in DB Handler's registry and will try to connect upon boot.",
+          "coderef": { "ref": "database/config/connections" }
+        },
+        {
+          "id": "drizzle",
+          "label": "Drizzle ORM",
+          "sublabel": "[driver: \"drizzle\"]",
+          "keywords": ["drizzle", "drizzle orm", "orm", "sql", "postgresql", "mysql", "sqlite", "database"],
+          "text": "Chasi includes a first-class Drizzle ORM driver. Declare a Drizzle connection in config/database.ts with driver: \"drizzle\", then access the live query client via this.models.connectionName._db or the static Model.drizzle(\"connectionName\") accessor."
+        },
+        {
+          "id": "drizzle-adapter",
+          "label": "adapter",
+          "reference": ["drizzle"],
+          "type": "<DrizzleAdapter>",
+          "keywords": ["drizzle adapter", "drizzle", "node-postgres", "mysql2", "better-sqlite3", "libsql", "postgres-js"],
+          "text": "The drizzle-orm sub-path to use for the connection. Determines which underlying database client is used. Supported values: \"node-postgres\" (pg), \"postgres-js\" (postgres), \"mysql2\", \"better-sqlite3\", \"libsql\" (Turso). The corresponding peer package must be installed separately."
+        },
+        {
+          "id": "drizzle-schema",
+          "label": "schema",
+          "reference": ["drizzle"],
+          "type": "<string>",
+          "keywords": ["drizzle schema", "drizzle", "table", "pgTable", "mysqlTable", "sqliteTable"],
+          "text": "Path to the schema file relative to src/. The file must export Drizzle table definitions as named exports. Each exported table is accessible as this.models.connectionName.tableName after boot. Do not use a default export — named exports only."
+        },
+        {
+          "id": "drizzle-globals",
+          "label": "globals",
+          "reference": ["drizzle"],
+          "type": "<Record<string, unknown>>",
+          "keywords": ["drizzle globals", "drizzle", "drizzle client", "mysql2 client", "postgres-js client"],
+          "text": "Extra options forwarded to the drizzle() constructor. Required for client-based adapters (mysql2, postgres-js) that cannot accept a bare connection string: pass the pre-built client as globals.client. Also accepts drizzle logger, cache, and other DrizzleConfig options."
+        },
+        {
+          "id": "drizzle-query",
+          "label": "Querying",
+          "reference": ["drizzle"],
+          "keywords": ["drizzle query", "drizzle", "select", "insert", "update", "delete", "orm"],
+          "text": "Access the Drizzle query client inside a controller via this.models.connectionName._db. Table definitions from the schema file are available as this.models.connectionName.tableName. Use drizzle-orm helpers (eq, and, or, etc.) for query conditions."
+        },
+        {
+          "id": "drizzle-model-method",
+          "label": "Model.drizzle()",
+          "reference": ["drizzle"],
+          "type": "<DrizzleDB>",
+          "keywords": ["drizzle model", "Model.drizzle", "drizzle static", "drizzle accessor"],
+          "text": "Static method on the base Model class that returns the live Drizzle query client for a named connection. Useful outside of controllers, for example in service providers or event handlers: Model.drizzle(\"connectionName\")."
+        }
+      ],
+      "controls": {
+        "right": { "open": true },
+        "header": { "subheader": { "open": false } }
+      }
+    },
+    {
+      "keywords": ["general"],
+      "id": "general",
+      "label": "general",
+      "display": false,
+      "glossary": [
+        { "id": "expressjs", "label": "express", "keywords": ["initialize", "init", "npm"], "text": "Express is a minimal and flexible Node.js web application framework that provides a robust set of features for web and mobile applications" },
+        { "id": "ServiceProvider", "label": "ServiceProvider", "keywords": ["ServiceProvider"], "text": "A way to manage inner/outer modules, chasi allows separation of logic/implementation. Developers can utilize this implementation to further isolate logic." },
+        { "id": "CompilerEngine", "label": "CompilerEngine", "keywords": ["compilerengine", "compiler", "engine"], "text": "chasi internal module that handles SSR and frontend stuff" },
+        { "id": "HTTPMethod", "label": "HTTP Method", "keywords": ["HTTP", "HTTPMethod", "protocol"], "text": "HTTP method of an endpoint, e.g. (GET, POST, PUT, DELETE, OPTIONS, PATCH, SEARCH). a full route endpoint can be similar but have a different HTTP method, and will be routed accordingly." },
+        { "id": "vitest", "label": "Vitest", "keywords": ["vitest", "testing", "test runner", "tdd"], "text": "A native test runner that magically works with TypeScript, and follows most common patterns in testing, but is lightning fast. You can check vitest website for more info: https://vitest.dev/" }
+      ]
+    },
+    {
+      "keywords": ["test", "testing", "api testing"],
+      "id": "testing",
+      "icon": "labs",
+      "label": "API Testing",
+      "display": true,
+      "subcats": [
+        { "to": "testing", "label": "TDD" },
+        {
+          "to": "testingShowcase",
+          "label": "setting up your test environment",
+          "group": ["tst-vitest-config", "tst-env"]
+        },
+        { "to": "testingUsages", "label": "example usage", "group": ["tst-usage"] }
+      ],
+      "glossary": [
+        {
+          "id": "testing",
+          "label": "TDD on Chasi",
+          "sublabel": "[./test/*.test.ts]",
+          "keywords": ["testing", "tdd", "api testing", "vitest"],
+          "text": "Test-Driven Development practice is fully supported by Chasi, Powered by vitest, developers can check the default vitest configuration in [<root>/vitest.config.ts], you can also check environment variables [<root>/test/.env.test] being passed when working with TDD. By default, when process.env[testMode] is enabled, compiler engines will be disabled as vitest will be working with [./src] directory with Typescript."
+        },
+        {
+          "id": "tst-vitest-config",
+          "label": "vitest.config.ts",
+          "reference": ["testingShowcase"],
+          "type": "https://vitest.dev/config/#env",
+          "keywords": ["vitest config", "config", "test config", "environment"],
+          "text": "Vitest can be configured at [<root>/vitest.config.ts], Chasi provides a default config that works with [<root>/test] directory, developers can check other vitest configurations that can be suitable for the needs at :https://vitest.dev/config/#env"
+        },
+        {
+          "id": "tst-env",
+          "label": "test environment",
+          "sublabel": "[./test/.env.test]",
+          "reference": ["testingShowcase"],
+          "type": "<environment variables>",
+          "keywords": ["test env vars", "environment variables"],
+          "text": "A separate Environment for testing. This is to enable developers to run an actual test with real environment, instead of mocking responses, though mocks can still be easily configured/created if needed."
+        },
+        {
+          "id": "tst-usage",
+          "label": "Testing /users/*",
+          "sublabel": "Testing endpoints [/users]",
+          "reference": ["testingUsages"],
+          "type": "<environment variables>",
+          "keywords": ["test usages", "usages", "example"],
+          "text": "Suppose we have a group of endpoints to test into our api, let's say /users endpoint. Implementing the default test configs, a file `user.test.ts` can be created under /test directory. And it may look like this at first"
+        }
+      ],
+      "controls": {
+        "right": { "open": true },
+        "header": { "subheader": { "open": false } }
+      }
+    }
+  ]
+}

--- a/src/package/framework/Database/Database.ts
+++ b/src/package/framework/Database/Database.ts
@@ -9,12 +9,15 @@ import chalk from "chalk";
 import Driver from "./drivers/drivers.js";
 import MongoDBDriver from "./drivers/mongodb.js";
 import PrismaDriver from "./drivers/prisma.js";
+import DrizzleDriver from "./drivers/drizzle.js";
+
 export default class Database implements ModuleInterface {
   $databases: DatabaseDrivers = {};
 
   $drivers: { [key: string]: Constructuble<Driver> } = {
     mongodb: MongoDBDriver as Constructuble<Driver>,
     prisma: PrismaDriver as Constructuble<Driver>,
+    drizzle: DrizzleDriver as Constructuble<Driver>,
   };
 
   static $log: { [key: string]: any } = {

--- a/src/package/framework/Database/Models.ts
+++ b/src/package/framework/Database/Models.ts
@@ -19,14 +19,20 @@ export default class Models extends Base {
         Models.collection[content?.modelName?.toLowerCase()] = content;
       });
     }
-    //prisma model collection
     Object.keys(this.$databases).map((db: string) => {
       let _d = this.$databases[db];
-      let models = _d["models"];
       Models.collection[db] = {};
+
       if (_d.driverName === "prisma") {
         Object.keys(_d["models"]).map((model) => {
           Models.collection[db][model] = _d["models"][model];
+        });
+      }
+
+      if (_d.driverName === "drizzle") {
+        // _db holds the live Drizzle query client; remaining keys are table definitions
+        Object.keys(_d["models"]).map((key) => {
+          Models.collection[db][key] = _d["models"][key];
         });
       }
     });

--- a/src/package/framework/Database/drivers/database.d.ts
+++ b/src/package/framework/Database/drivers/database.d.ts
@@ -1,6 +1,7 @@
 declare module "Chasi/Database" {
   import { Prisma, PrismaClient } from "@prisma/client";
-  export type drivers = "prisma" | "mongodb";
+
+  export type drivers = "prisma" | "mongodb" | "drizzle";
 
   export interface DBDriverInterface {
     config: DBProperty<drivers, U>;
@@ -29,49 +30,93 @@ declare module "Chasi/Database" {
     globals?: any;
   };
 
+  /**
+   * Supported Drizzle adapter sub-paths from drizzle-orm.
+   * The underlying database client package must be installed separately:
+   *   "node-postgres"   → npm i pg
+   *   "postgres-js"     → npm i postgres
+   *   "mysql2"          → npm i mysql2
+   *   "better-sqlite3"  → npm i better-sqlite3
+   *   "libsql"          → npm i @libsql/client
+   */
+  export type DrizzleAdapter =
+    | "node-postgres"
+    | "postgres-js"
+    | "mysql2"
+    | "better-sqlite3"
+    | "libsql"
+    | (string & {});
+
+  export type DrizzleOptions<U = unknown> = {
+    /**
+     * Drizzle adapter sub-path to import from drizzle-orm.
+     * e.g. "node-postgres" → drizzle-orm/node-postgres
+     */
+    adapter: DrizzleAdapter;
+
+    /**
+     * Path to the schema file (relative to src/).
+     * The file should export Drizzle table definitions as named exports.
+     * e.g. "./container/drizzle/schema"
+     * Once loaded, each table is accessible via:
+     *   this.models.connectionName.tableName
+     */
+    schema?: string;
+
+    /**
+     * Extra options forwarded directly to the drizzle() constructor.
+     * Use this to pass a pre-built client (required for mysql2, postgres-js):
+     *   globals: { client: mysqlConnection }
+     * or to configure Drizzle logger, cache, etc.:
+     *   globals: { logger: true }
+     */
+    globals?: Record<string, unknown>;
+  };
+
   export type DBProperty<drivers, U = null> = {
     driver: drivers;
+    /** Connection string / DSN. For SQLite, use the file path or ":memory:". */
     url: string;
-    db: string;
+    /**
+     * MongoDB database name (not used by Drizzle or Prisma drivers).
+     * Optional so Drizzle connections don't need to declare it.
+     */
+    db?: string;
     params?: string;
     hideLogConnectionStrings?: boolean;
-    options: PrismaOptions<U> | MongoDBOptions<U>;
+    options: PrismaOptions<U> | MongoDBOptions<U> | DrizzleOptions<U>;
   };
 
   export type DatabaseConfig = {
     /**
-     * Connection name
-     * declared in
-     * [DatabaseConfig.connections]
+     * Connection name declared in [DatabaseConfig.connections].
      */
     host: string;
 
     /**
-     * will throw an
-     * execution error
-     * if one of the DB connections
-     * failed to connect
+     * Throws an execution error if one of the DB connections failed to connect.
      */
     bootWithDB: boolean;
 
     /**
-     * the default connection
-     * to be used by the models
-     * if none is specified
+     * The default connection used by models that do not specify one.
      */
     default: string;
 
     /**
-     * hides the connection
-     * string in terminal
-     * logging
+     * Hides connection strings in terminal log output.
      */
     hideLogConnectionStrings: boolean;
 
     /**
-     * this is where database connections
-     * should be declared.
+     * Named database connection definitions. All entries connect at boot.
      */
     connections: Record<string, DBProperty<drivers, U>>;
+
+    /**
+     * Directories scanned for Mongoose model files.
+     * Not used by Drizzle or Prisma connections.
+     */
+    modelsDir?: string[];
   };
 }

--- a/src/package/framework/Database/drivers/drizzle.ts
+++ b/src/package/framework/Database/drivers/drizzle.ts
@@ -1,0 +1,114 @@
+import DB, { DBProperty, DrizzleOptions } from "Chasi/Database";
+import { Writable } from "../../../Logger/types/Writer.js";
+import Driver from "./drivers.js";
+import Base from "../../../Base.js";
+import chalk from "chalk";
+
+export default class DrizzleDriver extends Driver implements DB.DBDriverInterface {
+  public driverName = <DB.drivers>"drizzle";
+  public isDefaultDB = false;
+  public protocol = "";
+  public connection: any = null;
+  public db: any = null;
+  public models: Record<string, any> = {};
+  public logger: Writable & { subject?: string };
+
+  constructor(
+    public config: DBProperty<"drizzle", DrizzleOptions>,
+    public name: string
+  ) {
+    super(config);
+    this.name = name;
+    this.logger = Logger.writers.Left;
+    this.logger.subject = "database";
+  }
+
+  private get opts(): DrizzleOptions {
+    return this.config.options as DrizzleOptions;
+  }
+
+  /**
+   * Loads the Drizzle schema from the path declared in options.schema.
+   * The schema file should export Drizzle table definitions as named exports.
+   * Returns an empty object when no schema path is configured.
+   */
+  private async loadSchema(): Promise<Record<string, unknown>> {
+    if (!this.opts.schema) return {};
+    try {
+      const mod = (await Base._fetchFile(this.opts.schema, false)) as Record<string, unknown>;
+      const { default: _d, ...tables } = mod;
+      return tables;
+    } catch {
+      Logger.warn(
+        `DrizzleDriver[${this.name}]: could not load schema from "${this.opts.schema}" — proceeding without schema`
+      );
+      return {};
+    }
+  }
+
+  /**
+   * Dynamically imports the drizzle() factory from the configured adapter module.
+   * adapter must be a valid drizzle-orm sub-path, e.g. "node-postgres", "mysql2",
+   * "better-sqlite3", "libsql", "postgres-js".
+   */
+  private async getDrizzleFn(): Promise<Function> {
+    const mod = (await import(`drizzle-orm/${this.opts.adapter}`)) as {
+      drizzle: Function;
+    };
+    return mod.drizzle;
+  }
+
+  /**
+   * Populates this.models with:
+   *   _db  — the live Drizzle query client
+   *   [tableKey] — each named export from the schema file
+   * Accessible in controllers as:
+   *   this.models.myConn._db  (query client)
+   *   this.models.myConn.users (table definition)
+   */
+  setModels(schema: Record<string, unknown>): void {
+    this.models._db = this.db;
+    Object.keys(schema).forEach((key) => {
+      this.models[key] = schema[key];
+    });
+  }
+
+  async connect(stop: (msg: string) => void): Promise<any> {
+    try {
+      const schema = await this.loadSchema();
+      const drizzleFn = await this.getDrizzleFn();
+
+      // If options.globals contains a pre-built `client`, skip passing `connection`
+      // so the developer's client takes precedence (required for mysql2, postgres-js, etc.).
+      // For adapters that accept a connection string directly (node-postgres, better-sqlite3,
+      // libsql) the url field is forwarded as `connection`.
+      const drizzleConfig: Record<string, unknown> = {
+        ...(this.opts.globals?.client ? {} : { connection: this.config.url }),
+        ...(Object.keys(schema).length > 0 ? { schema } : {}),
+        ...(this.opts.globals ?? {}),
+      };
+
+      this.db = drizzleFn(drizzleConfig);
+      this.connection = this.db;
+      this.setModels(schema);
+
+      stop(
+        `  ╡[${this.states[1]("•")}]${
+          this.isDefaultDB
+            ? chalk.greenBright.underline(this.name.toUpperCase())
+            : this.name.toUpperCase()
+        }`
+      );
+
+      if (this.config.hideLogConnectionStrings) {
+        this.logger.write(` - [drizzle/${this.opts.adapter}] (connection string hidden)\n`);
+      } else {
+        this.logger.write(` - ${this.config.url}\n`);
+      }
+
+      return this.db;
+    } catch (e) {
+      throw e;
+    }
+  }
+}

--- a/src/package/framework/Database/drivers/mongodb.ts
+++ b/src/package/framework/Database/drivers/mongodb.ts
@@ -30,7 +30,7 @@ export default class MongoDBDriver extends Driver implements DBDriverInterface {
   }
 
   setup() {
-    this.$property.url = this.config.url + this.config.db;
+    this.$property.url = this.config.url + (this.config.db ?? "");
     if (this.config.params) this.$property.url += this.config.params;
     if (this.config.options) {
       this.hasOptions = true;

--- a/src/package/statics/Model.ts
+++ b/src/package/statics/Model.ts
@@ -1,12 +1,14 @@
-import mongoose, { Schema, model, HydratedDocument } from "mongoose";
+import mongoose, { Schema } from "mongoose";
 import Models from "../framework/Database/Models.js";
 
 export default class Model extends Models {
-  /** static[connect()]
-   * method that specifies a connection of a model.
-   * @param name[String] schema name
-   * @param schema[Mongoose.Schema] object
-   * @param connection[string] connection name where this model will connect to. default is "_"
+  /**
+   * Registers a Mongoose schema against a named MongoDB connection.
+   * Returns a Mongoose Model bound to that connection's live socket.
+   *
+   * @param name       Schema / collection name
+   * @param schema     Mongoose Schema object
+   * @param connection Connection key from config/database.ts (default: "_")
    */
   static connect<T = {}, K = {}>(
     name: string,
@@ -14,7 +16,6 @@ export default class Model extends Models {
     connection: string = "_"
   ): mongoose.Model<T, K> {
     try {
-
       if (Model.$databases[connection].config.driver === "mongodb") {
         if (Model.$databases[connection]?.connection) {
           return Model.$databases[connection]?.connection?.model(
@@ -23,11 +24,33 @@ export default class Model extends Models {
           ) as mongoose.Model<T, K>;
         }
       }
-
     } catch (e) {
       Logger.log(`Model[${name}] unable to connect to Con[${connection}]`);
       Logger.log(e);
     }
+  }
 
+  /**
+   * Returns the live Drizzle query client for a named connection.
+   * Use this inside a model or controller to run Drizzle queries:
+   *
+   *   const db = Model.drizzle("myPgConn");
+   *   const rows = await db.select().from(users);
+   *
+   * Schema tables are also accessible via this.models.connectionName.tableName.
+   *
+   * @param connection Connection key from config/database.ts (default: "_")
+   */
+  static drizzle(connection: string = "_"): any {
+    const driver = Model.$databases[connection];
+    if (!driver) {
+      throw new Error(`[Drizzle] No connection found for "${connection}".`);
+    }
+    if (driver.driverName !== "drizzle") {
+      throw new Error(
+        `[Drizzle] Connection "${connection}" uses driver "${driver.driverName}", not "drizzle".`
+      );
+    }
+    return driver.connection;
   }
 }


### PR DESCRIPTION
- Updated version in package.json to 3.6.0.
- Added Drizzle ORM as a new database driver, supporting PostgreSQL, MySQL, SQLite, and Turso.
- Enhanced README.md to include Drizzle ORM documentation and usage examples.
- Updated database configuration files to support Drizzle connections.
- Introduced new components and code examples for Drizzle integration in the frontend.
- Improved type definitions and documentation for better clarity and usability.