### PR TITLE
chore: release v3.6.1 with Observer event bus documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,93 @@ Use `$getConnection("connectionName")` inside a controller to switch connections
 
 ---
 
+## Observer & Events
+
+Chasi includes an async **Observer** event bus. A single instance is created at boot from `src/config/observer.ts` and exposed as `$observer` on the app `Handler` and on every controller via `this.$observer`.
+
+### What the Observer does
+
+- Loads and registers **custom Event classes** listed in config (`Observer.setup()` at startup)
+- Dispatches events through an `AsyncEventEmitter` with a fixed pipeline: `validate` → `onemit` → `fire` → `fireListeners` → `emitted`
+- Orchestrates **framework lifecycle** during boot (`__before__`, `__initialize__`, `__after__`, `__boot__`, `__ready__`, `__exception__`) — these Horizon events live under `src/package/statics/horizon/events/` and are not listed in `observer.ts`
+
+### Registering custom events (required)
+
+A custom event **must** be declared in `src/config/observer.ts` under `events` before you can use it. At boot, `Observer.setup()` reads that map, loads each class from `src/container/events/` (or your path), and registers the alias on the emitter. If an alias is missing from config, `emit("thatAlias")` will not run your handler.
+
+```ts
+events: {
+  authorized: "container/events/Authorize", // required — alias → path relative to src/
+},
+```
+
+### How events run (isolated from the request)
+
+Event work runs on the async emitter, **not on the Express request/response stack**. In a controller:
+
+- **Fire-and-forget** (typical for side effects): `this.$observer.emit("authorized", { ... })` **without** `await` — the handler can call `res.json()` and the client gets a response while the event pipeline still runs.
+- **Wait for completion**: `await this.$observer.emit(...)` — use when the response must not be sent until the event finishes.
+
+Once detached (no `await`), a failure inside `fire()` does not change an HTTP status code that was already sent; handle errors inside the event or use `await` when the client must wait.
+
+### Configuration (`src/config/observer.ts`)
+
+Typed as `ObserverConfig` from `src/package/Observer/index.ts`:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `events` | `events` (`Record<string, string>`) | Maps event alias → class path relative to `src/` (no extension) |
+| `beforeEmit` | `Function` | Global hook before `fire()`; `this` is the Event instance |
+| `afterEmit` | `Function` | Global hook after `fire()` and listeners; skipped if the event overrides `emitted` |
+
+```ts
+// src/config/observer.ts
+export default <ObserverConfig>{
+  events: {
+    authorized: "container/events/Authorize",
+  },
+  beforeEmit: async function (params) { /* runs before every event's fire() */ },
+  afterEmit: async function (params) { /* runs after fire() + listeners */ },
+};
+```
+
+### Custom Event classes
+
+Create a class under `src/container/events/` that extends `Event` and implements `EventInterface`:
+
+```ts
+import Event, { EventInterface } from "../../package/Observer/Event.js";
+
+export default class Authorize extends Event implements EventInterface {
+  async validate(params, next) {
+    next(); // required — or throw to abort
+  }
+  async fire(params) {
+    // side effects: audit, notify, etc.
+  }
+}
+```
+
+### Emitting and listening
+
+```ts
+// In a controller — response can return before the event finishes (no await)
+this.$observer.emit("authorized", { userId: req.user.id });
+return this.res.json({ ok: true });
+
+// Or block until the event completes
+await this.$observer.emit("authorized", { userId: req.user.id });
+
+// In a service provider — subscribe to lifecycle or custom events
+Provider.$observer.when("__ready__", async (_prop, params) => {
+  Logger.info("Server ready", params.server?.address());
+});
+```
+
+> Full interactive docs for Observer and Events are in the built-in documentation UI (sidebar **Observer**) when you run `npm run dev` and open `http://localhost:3010`.
+
+---
+
 ## Drizzle ORM
 
 Chasi has a first-class Drizzle driver that supports PostgreSQL, MySQL, SQLite, and Turso. Drizzle connections live alongside MongoDB/Prisma connections in the same `src/config/database.ts` file.
@@ -573,6 +660,7 @@ Switch between `"dev"` (Vite HMR) and `"prod"` (static build) by changing the `e
 - Requirements now indexed in global search — searchable by keyword (`node`, `npm`, `git`, `requirements`, `version`)
 - Drizzle ORM entries added to the database section of the built-in docs (searchable adapter, schema, globals, querying, and `Model.drizzle` glossary items)
 - Documentation frontend updated to v3.6.0 as default version
+- Added **Observer** documentation page (Observer vs Events, `ObserverConfig` / `events` types, config file reference)
 
 ### v3.5.0
 - Added **Drizzle ORM** database driver — supports PostgreSQL, MySQL, SQLite, and Turso alongside existing MongoDB/Prisma connections

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chasi-ts",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "",
   "main": "dist/server.js",
   "type": "module",

--- a/src/config/compiler.ts
+++ b/src/config/compiler.ts
@@ -30,7 +30,7 @@ const config: CompilerEngineConfig = {
    * Set to `false` to disable all Vite compilation (e.g. API-only servers
    * that serve no frontend assets).
    */
-  enabled: true,
+  enabled: false,
 
   /**
    * List of Vite engine instances to manage.

--- a/src/config/container.ts
+++ b/src/config/container.ts
@@ -36,6 +36,7 @@ export default <ContainerConfig>{
     compiler: "container/services/CompilerEngineServiceProvider",
     routers: "container/services/RouterServiceProvider",
     sockets: "container/services/SocketServiceProvider",
+    apispec: "container/services/ApiSpecServiceProvider"
   },
 
   /**

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -31,7 +31,7 @@ export default <DatabaseConfig>{
   default: checkout(process.env.database, "local"),
 
   /**
-   * Named database connection definitions.
+   * Named database connection definitions. 
    * All entries are connected automatically during the boot sequence.
    * Reference a specific connection inside a model or via
    * `$getConnection("ConnectionName")` in a controller — if the name doesn't

--- a/src/config/observer.ts
+++ b/src/config/observer.ts
@@ -1,42 +1,72 @@
-import { Writable } from "../package/Logger/types/Writer.js";
 import { ObserverConfig } from "../package/Observer/index.js";
 
-let logger: Writable = Logger.writer();
-
+/**
+ * Observer configuration (`src/config/observer.ts`).
+ *
+ * Loaded by `Handler` and passed to `new Observer(config)`. Controls which
+ * application Event classes are registered and optional global hooks around
+ * every event's `fire()` pipeline.
+ *
+ * @see `ObserverConfig` — `{ events, beforeEmit, afterEmit }` in `package/Observer/index.ts`
+ * @see `events` — `Record<string, string>` alias → path relative to `src/`
+ * @see `EventInterface` — contract for classes under `container/events/`
+ *
+ * **Registration** — Custom events are only available after you add them here.
+ * `emit("myEvent")` has no handler until the alias is listed and the app has restarted.
+ *
+ * **Execution** — Events run on the async emitter, isolated from the HTTP request.
+ * In controllers, calling `emit()` without `await` lets the response return while
+ * `validate` → `fire` → listeners still run in the background.
+ */
 export default <ObserverConfig>{
   /**
-   * Named event registry.
-   * Maps an event alias to the path of its Event class file
-   * (relative to `src/`, resolved at boot time).
+   * Named event registry (`events` type: `Record<string, string>`).
    *
-   * Once registered, fire an event anywhere inside a controller with:
-   *   `this.$observer.emit("authorized", { ...payload })`
+   * **Required for custom events.** Only aliases listed here are loaded at boot and
+   * can be passed to `$observer.emit()`. Add the class under `container/events/`,
+   * map the alias to its path, then restart (or rely on dev reload).
    *
-   * Each event class must implement the `EventInterface` (see `package/Observer/Event.ts`).
-   * Add new events here to have them auto-registered during startup.
+   * Maps an event **alias** (first argument to `$observer.emit`) to the path of
+   * its Event class file, relative to `src/` and without a file extension.
+   * Resolved at boot in `Observer.setup()` via dynamic import.
+   *
+   * @example
+   * ```ts
+   * events: {
+   *   authorized: "container/events/Authorize",
+   * }
+   * // later in a controller:
+   * await this.$observer.emit("authorized", { userId: "..." });
+   * ```
+   *
+   * Each class must extend `Event` and implement `EventInterface`
+   * (`package/Observer/Event.ts`).
    */
   events: {
     authorized: "container/events/Authorize",
   },
 
   /**
-   * Global hook called just before every event's `fire()` method executes.
-   * Applies to all registered events unless the event class overrides `onemit()`.
-   * Use this to inject cross-cutting logic (logging, tracing, validation setup)
-   * without touching individual event files.
+   * Global `beforeEmit` hook — runs in `Event.onemit()` before `fire()`.
    *
-   * `this` inside the function refers to the Event instance.
-   * `params` is the payload passed to `$observer.emit(...)`.
+   * Applies to every registered event whose class does **not** define its own
+   * `onemit()` / `beforeEmit`. Use for cross-cutting setup: tracing, shared
+   * validation context, or structured logging.
+   *
+   * - `this` — the `Event` instance
+   * - `params` — payload passed to `$observer.emit(alias, params)`
    */
   beforeEmit: async function (params) {},
 
   /**
-   * Global hook called just after every event's `fire()` method completes.
-   * Applies to all registered events unless the event class overrides `emitted()`.
-   * Use this for post-event cleanup, audit logging, or metric recording.
+   * Global `afterEmit` hook — runs in `Event.emitted()` after `fire()` and
+   * `when()` listeners complete.
    *
-   * `this` inside the function refers to the Event instance.
-   * `params` is the same payload that was passed to `$observer.emit(...)`.
+   * Applies unless the event class overrides `emitted()` / `afterEmit`.
+   * Use for audit logs, metrics, or cleanup.
+   *
+   * - `this` — the `Event` instance
+   * - `params` — same payload from `emit()`
    */
   afterEmit: async function (params) {},
 };

--- a/src/container/controllers/v1/UserController.ts
+++ b/src/container/controllers/v1/UserController.ts
@@ -11,6 +11,13 @@ export default class UserController extends Controller {
    * */
   async create(request, response) {
     // maybe add some validations here ?
+    let {email} = request.body;
+    if (await this.user.findOne({email})) {
+      throw {
+        status: 400,
+        message: "Email already exists"
+      }
+    }
     return await this.user.create({...request.body})
   }
 

--- a/src/container/html/web/src/components/observer/what.vue
+++ b/src/container/html/web/src/components/observer/what.vue
@@ -1,0 +1,286 @@
+<template>
+  <div>
+    <section class="section">
+      <div class="pan-title">
+        <div class="x-center is-size-3">
+          <span>
+            <hook id="observer" />
+            {{ observer.label }}
+          </span>
+        </div>
+        <small>
+          <span class="subtitle">{{ observer.sublabel }}</span>
+        </small>
+      </div>
+      <span class="sub-text">
+        The <strong>Observer</strong> is Chasi's async event bus. One instance is created at boot from
+        <code>src/config/observer.ts</code> and attached to the app as <code>$observer</code>. It powers
+        the server lifecycle (<tag v-bind="{ name: '__before__', style: 'is-link', reference: 'obs-lifecycle' }" />,
+        <tag v-bind="{ name: '__ready__', style: 'is-link', reference: 'obs-lifecycle' }" />, etc.) and
+        lets you register your own named <strong>Events</strong> for decoupled side effects — logging,
+        notifications, cache invalidation — without bloating controllers.
+      </span>
+    </section>
+
+    <section class="section">
+      <div class="pan-title">
+        <div class="x-center is-size-3">
+          <span><hook id="obs-execution" /> How events run</span>
+        </div>
+      </div>
+      <span class="sub-text">
+        Custom events must be listed in <code>src/config/observer.ts</code> under
+        <tag v-bind="{ name: 'events', style: 'is-primary', reference: 'obs-events' }" />
+        before you can <code>emit()</code> them — only aliases registered at boot (via
+        <code>Observer.setup()</code>) are loaded and wired to the emitter.
+      </span>
+      <span class="sub-text" style="display: block; margin-top: 1rem;">
+        When an event is dispatched, the Observer runs its pipeline on the async emitter
+        (<code>validate</code> → <code>onemit</code> → <code>fire</code> → <code>fireListeners</code> →
+        <code>emitted</code>) in a path that is <strong>isolated from the HTTP request</strong>.
+        In a controller, if you call <code>this.$observer.emit(...)</code> <em>without</em>
+        <code>await</code>, the handler can send the response immediately while the event keeps
+        running in the background — the client may already have the response before
+        <code>fire()</code> finishes. Use that for side effects you do not want to block the request;
+        use <code>await this.$observer.emit(...)</code> only when the response must wait for the event.
+      </span>
+    </section>
+
+    <section class="section">
+      <div class="pan-title">
+        <div class="x-center is-size-3">
+          <span><hook id="observerConfig" /> Configuration</span>
+          <span class="tag is-info is-light is-medium">&lt;ObserverConfig&gt;</span>
+        </div>
+        <small>
+          <span class="subtitle">[./src/config/observer.ts]</span>
+        </small>
+      </div>
+      <span class="sub-text">
+        <tag v-bind="{ name: 'ObserverConfig', style: 'is-primary', reference: 'obs-ObserverConfig' }" />
+        is the typed shape of this file. It has three members: an <code>events</code> registry,
+        and optional global <code>beforeEmit</code> / <code>afterEmit</code> hooks that wrap every
+        custom event's <code>fire()</code> unless an event class overrides them.
+      </span>
+    </section>
+    <list
+      :items="configList.list"
+      :header="{ name: '<ObserverConfig>', hook: 'observerConfig' }"
+    />
+
+    <section class="section">
+      <div class="pan-title">
+        <div class="x-center is-size-3">
+          <span><hook id="observerEvents" /> Events</span>
+          <span class="tag is-info is-light is-medium">EventInterface</span>
+        </div>
+        <small>
+          <span class="subtitle">[./src/container/events/] · [package/Observer/Event.ts]</span>
+        </small>
+      </div>
+      <span class="sub-text">
+        An <strong>Event</strong> is a class extending
+        <code>package/Observer/Event.ts</code> and implementing
+        <tag v-bind="{ name: 'EventInterface', style: 'is-primary', reference: 'obs-event-class' }" />.
+        When you call <tag v-bind="{ name: 'emit()', style: 'is-link', reference: 'obs-emit' }" />,
+        the Observer runs: <code>validate</code> → <code>onemit</code> (global <code>beforeEmit</code>) →
+        <code>fire</code> → <code>fireListeners</code> (<tag v-bind="{ name: 'when()', style: 'is-link', reference: 'obs-when' }" /> callbacks) →
+        <code>emitted</code> (global <code>afterEmit</code>).
+      </span>
+    </section>
+
+    <list
+      :items="eventInterfaceList.list"
+      :header="{ name: '<EventInterface>', hook: 'observerEvents' }"
+    />
+
+    <list
+      :items="eventsApiList.list"
+      :header="{ name: 'Observer API', desc: 'dispatch & lifecycle', hook: 'obs-emit' }"
+    />
+
+    <section class="section">
+      <div class="x-center is-size-5">
+        <span><hook id="obs-emit" /> Emit from a controller</span>
+      </div>
+      <code-container mapping="observer/events/emit" :options="{ theme: 'vitesse-dark', lang: 'ts' }">
+        <template v-slot:comment>
+          <p>Controller — dispatch a registered event</p>
+        </template>
+      </code-container>
+    </section>
+
+    <section class="section">
+      <div class="x-center is-size-5">
+        <span><hook id="obs-event-class" /> Define a custom event</span>
+      </div>
+      <code-container mapping="observer/events/eventClass" :options="{ theme: 'vitesse-dark', lang: 'ts' }">
+        <template v-slot:comment>
+          <p>Event class — e.g. ./src/container/events/Authorize.ts</p>
+        </template>
+      </code-container>
+    </section>
+
+    <section class="section">
+      <div class="x-center is-size-5">
+        <span><hook id="obs-when" /> Listen with when()</span>
+      </div>
+      <code-container mapping="observer/events/when" :options="{ theme: 'vitesse-dark', lang: 'ts' }">
+        <template v-slot:comment>
+          <p>Service provider — hook __ready__ at boot</p>
+        </template>
+      </code-container>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import tag from "@/components/utils/tag/tag.vue"
+import { reactive } from "vue"
+import { useControlStore } from "@/stores/ControlStore"
+
+const ctx = useControlStore()
+const observer = ctx.dict["observer"]
+
+const configList = reactive({
+  list: [
+    {
+      hook: "obs-events",
+      title: "events",
+      sub: "[ObserverConfig.events]",
+      tag: "events",
+      desc: `Required registry before <code>emit()</code> works for custom events. Add every alias here with its class path (relative to <code>src/</code>, no extension). Unregistered aliases are not loaded at boot and will not run. Entries are registered in <code>Observer.setup()</code> on startup.`,
+      codeContent: {
+        mapping: "observer/config/events",
+        comment: "// src/config/observer.ts",
+        options: { lang: "ts", theme: "vitesse-dark" },
+      },
+    },
+    {
+      hook: "obs-beforeEmit",
+      title: "beforeEmit",
+      sub: "[ObserverConfig.beforeEmit]",
+      tag: "(params) => Promise<void>",
+      desc: `Global hook run in <code>onemit()</code> before <code>fire()</code>. <code>this</code> is the Event instance; <code>params</code> is the emit payload. Skipped when the event class defines its own <code>onemit</code> / <code>beforeEmit</code>.`,
+      codeContent: {
+        mapping: "observer/config/beforeEmit",
+        options: { lang: "ts", theme: "vitesse-dark" },
+      },
+    },
+    {
+      hook: "obs-afterEmit",
+      title: "afterEmit",
+      sub: "[ObserverConfig.afterEmit]",
+      tag: "(params) => Promise<void>",
+      desc: `Global hook run in <code>emitted()</code> after <code>fire()</code> and listeners finish. Use for audit trails or metrics. Skipped when the event defines its own <code>emitted</code> / <code>afterEmit</code>.`,
+      codeContent: {
+        mapping: "observer/config/afterEmit",
+        options: { lang: "ts", theme: "vitesse-dark" },
+      },
+    },
+    {
+      hook: "obs-ObserverConfig",
+      title: "ObserverConfig",
+      sub: "[package/Observer/index.ts]",
+      tag: "type",
+      desc: `Exported type: <code>{ events: events; beforeEmit: Function; afterEmit: Function }</code>. The <code>events</code> field uses <code>Record&lt;string, string&gt;</code> (alias → class path).`,
+    },
+  ],
+})
+
+const eventInterfaceList = reactive({
+  list: [
+    {
+      hook: "obs-ev-props",
+      title: "props",
+      sub: "[EventInterface.props]",
+      tag: "{ [key: string]: any }",
+      desc: `Injected hook bag from config — holds global <code>beforeEmit</code> and <code>afterEmit</code> when the event class does not override them.`,
+    },
+    {
+      hook: "obs-ev-logger",
+      title: "logger",
+      sub: "[EventInterface.logger]",
+      tag: "Writer",
+      desc: `Log writer instance on the event (base <code>Event</code> uses <code>Logger.writer("StartTrace")</code>).`,
+    },
+    {
+      hook: "obs-ev-listeners",
+      title: "listeners",
+      sub: "[EventInterface.listeners]",
+      tag: "Listener[]",
+      desc: `Listeners attached via <code>$observer.when()</code>; invoked in <code>fireListeners()</code> after <code>fire()</code>.`,
+    },
+    {
+      hook: "obs-ev-validate",
+      title: "validate",
+      sub: "[EventInterface.validate]",
+      tag: "(params, next) => void",
+      desc: `Gate before the pipeline continues. Must call <code>next()</code> to proceed to <code>onemit</code> / <code>fire</code>; throw or omit <code>next()</code> to abort.`,
+    },
+    {
+      hook: "obs-ev-onemit",
+      title: "onemit",
+      sub: "[EventInterface.onemit]",
+      tag: "() => Promise<void>",
+      desc: `Runs before <code>fire()</code>. Base implementation applies global <code>beforeEmit</code> from <code>props</code>. Override to replace the global hook for this event.`,
+    },
+    {
+      hook: "obs-ev-fire",
+      title: "fire",
+      sub: "[EventInterface.fire]",
+      tag: "(params) => void | Promise<void>",
+      desc: `Main handler — implement your side effects here. Receives the payload passed to <code>emit()</code> (also on <code>this.options</code> in the base class).`,
+    },
+    {
+      hook: "obs-ev-fireListeners",
+      title: "fireListeners",
+      sub: "[EventInterface.fireListeners]",
+      tag: "() => Promise<void>",
+      desc: `Runs all <code>when()</code> callbacks registered for this event alias.`,
+    },
+    {
+      hook: "obs-ev-emitted",
+      title: "emitted",
+      sub: "[EventInterface.emitted]",
+      tag: "() => Promise<void>",
+      desc: `Runs after <code>fire()</code> and listeners. Base implementation applies global <code>afterEmit</code> from <code>props</code>. Override to replace the global hook.`,
+    },
+  ],
+})
+
+const eventsApiList = reactive({
+  list: [
+    {
+      hook: "obs-execution",
+      title: "Execution model",
+      sub: "[async / detached]",
+      tag: "behavior",
+      desc: `Events run through <code>AsyncEventEmitter</code>, separate from Express request/response timing. Omit <code>await</code> on <code>emit()</code> in controllers to return the HTTP response while the event pipeline still runs. Errors inside detached events do not change an already-sent status code — handle failures inside <code>fire()</code> or use <code>await emit()</code> when the client must wait.`,
+    },
+    {
+      hook: "obs-emit",
+      title: "$observer.emit()",
+      sub: "[Observer.emit]",
+      tag: "(event, params?) => Promise<void>",
+      desc: `Dispatch a <strong>registered</strong> event by alias (must exist in <code>observer.ts</code> <code>events</code>). On controllers: <code>this.$observer</code>. Fire-and-forget: <code>this.$observer.emit("authorized", payload)</code> without <code>await</code>. Block the handler until done: <code>await this.$observer.emit(...)</code>.`,
+    },
+    {
+      hook: "obs-when",
+      title: "$observer.when()",
+      sub: "[Observer.when]",
+      tag: "(key, fn, opts?) => void",
+      desc: `Subscribe a listener to an event. The callback receives <code>(listenerParams, emitParams)</code>. Common for wiring service providers to <code>__ready__</code> and other lifecycle events.`,
+    },
+    {
+      hook: "obs-lifecycle",
+      title: "Lifecycle events",
+      sub: "[horizon/events]",
+      tag: "built-in",
+      desc: `Framework events orchestrate boot: <code>__before__</code>, <code>__initialize__</code>, <code>__after__</code>, <code>__boot__</code>, <code>__ready__</code>, <code>__exception__</code>. These live under <code>package/statics/horizon/events/</code> and are not listed in <code>observer.ts</code> — they are registered internally by the framework.`,
+    },
+  ],
+})
+</script>
+
+<style scoped></style>

--- a/src/container/html/web/src/data/codemap.ts
+++ b/src/container/html/web/src/data/codemap.ts
@@ -519,6 +519,7 @@ describe("[POST /signin]", async () => {
         expect(res.body).toHaveProperty("token")
       })
     })`,
+    },
     onSuccessTest: `$ npm run test
 RERUN  test/user.test.ts x2
 
@@ -538,6 +539,65 @@ Test Files  1 passed (1)
 
 PASS  Waiting for file changes...
       press h to show help, press q to quit`
+  },
+  observer: {
+    config: {
+      events: `
+export default <ObserverConfig>{
+  events: {
+    // alias → path relative to src/ (no extension)
+    authorized: "container/events/Authorize",
+  },
+  beforeEmit: async function (params) {},
+  afterEmit: async function (params) {},
+}`,
+      beforeEmit: `
+// Global hook — runs before every event's fire() (via onemit)
+// this = Event instance, params = emit payload
+beforeEmit: async function (params) {
+  Logger.info("Event starting", params);
+}`,
+      afterEmit: `
+// Global hook — runs after fire() and listeners complete (via emitted)
+afterEmit: async function (params) {
+  Logger.info("Event finished", params);
+}`,
+    },
+    events: {
+      emit: `
+// Inside any controller — "authorized" must be in src/config/observer.ts events map
+
+async index() {
+  // Fire-and-forget: response returns while the event still runs
+  this.$observer.emit("authorized", {
+    userId: this.req.user?.id,
+    action: "login",
+  });
+  return this.res.json({ ok: true });
+
+  // Or await when the client must wait for the event to finish:
+  // await this.$observer.emit("authorized", { userId: this.req.user?.id });
+}`,
+      eventClass: `
+import Event, { EventInterface } from "../../package/Observer/Event.js";
+
+export default class Authorize extends Event implements EventInterface {
+  async validate(params, next) {
+    if (!params?.userId) throw new Error("userId required");
+    next();
+  }
+
+  async fire(params) {
+    // side effects: audit log, notify, etc.
+    Logger.info("User authorized", params.userId);
+  }
+}`,
+      when: `
+// In a service provider boot() — listen for server ready
+Provider.$observer.when("__ready__", async (_prop, params) => {
+  const server = params.server;
+  Logger.info("HTTP server listening", server?.address());
+});`,
     }
   }
 }

--- a/src/container/html/web/src/data/versions/v3.0.0.json
+++ b/src/container/html/web/src/data/versions/v3.0.0.json
@@ -184,6 +184,131 @@
       }
     },
     {
+      "keywords": ["observer", "event", "events", "emitter", "event-handler"],
+      "id": "observer",
+      "icon": "local_activity",
+      "label": "Observer",
+      "display": true,
+      "subcats": [
+        { "to": "observer", "label": "Observer" },
+        { "to": "obs-execution", "label": "How events run" },
+        {
+          "to": "observerConfig",
+          "label": "Configuration",
+          "group": ["obs-events", "obs-beforeEmit", "obs-afterEmit", "obs-ObserverConfig"]
+        },
+        {
+          "to": "observerEvents",
+          "label": "Events",
+          "group": ["obs-event-class", "obs-emit", "obs-when", "obs-lifecycle"]
+        }
+      ],
+      "glossary": [
+        {
+          "id": "observer",
+          "label": "Observer",
+          "sublabel": "[./src/package/Observer/index.ts]",
+          "keywords": ["observer", "event bus", "async emitter", "$observer"],
+          "text": "Chasi's built-in async event system. A single Observer instance is created at boot from src/config/observer.ts and exposed as $observer on the Handler and on every Controller (this.$observer). Custom events must be registered in observer.ts before emit() can use them. Event execution runs on the async emitter, isolated from the HTTP request — omit await on emit() in controllers to return a response while the event pipeline still runs."
+        },
+        {
+          "id": "obs-execution",
+          "label": "How events run",
+          "reference": ["observer"],
+          "keywords": ["execution", "async", "fire and forget", "detached", "background", "await"],
+          "text": "Custom events must be listed in src/config/observer.ts events before emit(alias) works. When dispatched, the pipeline (validate → onemit → fire → fireListeners → emitted) runs on AsyncEventEmitter, separate from Express request/response timing. In controllers, this.$observer.emit(...) without await lets res.json() return immediately while the event continues. Use await only when the client must wait. Errors in a detached event do not change an HTTP status already sent."
+        },
+        {
+          "id": "observerConfig",
+          "label": "Observer configuration",
+          "sublabel": "[./src/config/observer.ts]",
+          "reference": ["observer"],
+          "keywords": ["observer config", "ObserverConfig", "observer.ts"],
+          "text": "Typed as ObserverConfig. Maps custom event aliases to class paths under src/, and optionally defines global beforeEmit and afterEmit hooks that wrap every event's fire() unless an event class overrides onemit or emitted."
+        },
+        {
+          "id": "obs-events",
+          "label": "events",
+          "reference": ["observerConfig"],
+          "type": "events",
+          "keywords": ["events registry", "ObserverConfig events", "register event"],
+          "text": "Required registry for custom events. Every alias you pass to emit() must appear here with a class path relative to src/ (no extension). Unlisted aliases are not loaded at boot and will not run. Registered during Observer.setup() on startup — restart after adding new events.",
+          "coderef": { "ref": "observer/config/events" }
+        },
+        {
+          "id": "obs-beforeEmit",
+          "label": "beforeEmit",
+          "reference": ["observerConfig"],
+          "type": "(params) => Promise<void>",
+          "keywords": ["beforeEmit", "global hook", "pre-event"],
+          "text": "Global hook invoked in onemit() immediately before an event's fire() runs. `this` is the Event instance; `params` is the payload from emit(). Skipped for events that define their own onemit/beforeEmit.",
+          "coderef": { "ref": "observer/config/beforeEmit" }
+        },
+        {
+          "id": "obs-afterEmit",
+          "label": "afterEmit",
+          "reference": ["observerConfig"],
+          "type": "(params) => Promise<void>",
+          "keywords": ["afterEmit", "global hook", "post-event"],
+          "text": "Global hook invoked in emitted() after fire() and when() listeners complete. Use for audit logging or metrics. Skipped when the event class defines its own emitted/afterEmit.",
+          "coderef": { "ref": "observer/config/afterEmit" }
+        },
+        {
+          "id": "obs-ObserverConfig",
+          "label": "ObserverConfig",
+          "reference": ["observerConfig"],
+          "type": "ObserverConfig",
+          "keywords": ["ObserverConfig", "observer types", "events type"],
+          "text": "Type exported from package/Observer/index.ts: { events: events; beforeEmit: Function; afterEmit: Function }. The nested events type is Record<string, string> — event alias → src-relative class path."
+        },
+        {
+          "id": "observerEvents",
+          "label": "Events",
+          "sublabel": "[./src/container/events/]",
+          "keywords": ["events", "Event class", "EventInterface", "custom events"],
+          "text": "Custom events are classes extending package/Observer/Event.ts and implementing EventInterface. Each implements validate(params, next) and fire(params). Framework lifecycle events (__before__, __ready__, etc.) live under package/statics/horizon/events/ and are registered internally — not in observer.ts events map."
+        },
+        {
+          "id": "obs-event-class",
+          "label": "Event class",
+          "reference": ["observerEvents"],
+          "type": "EventInterface",
+          "keywords": ["Event", "EventInterface", "Authorize", "container/events"],
+          "text": "Extend Event and implement validate (must call next()) and fire. Listeners from when() run in fireListeners after fire(). Example: src/container/events/Authorize.ts mapped as authorized in observer config.",
+          "coderef": { "ref": "observer/events/eventClass" }
+        },
+        {
+          "id": "obs-emit",
+          "label": "$observer.emit()",
+          "reference": ["observerEvents"],
+          "type": "(event: string, params?: Record<string, unknown>) => Promise<void>",
+          "keywords": ["emit", "dispatch event", "fire event"],
+          "text": "Dispatch a registered event by alias (must exist in observer.ts events). Fire-and-forget in controllers: this.$observer.emit('authorized', payload) without await — response can return while fire() still runs. Block until done: await this.$observer.emit(...). Also on Handler.Instance.$observer and Provider.$observer.",
+          "coderef": { "ref": "observer/events/emit" }
+        },
+        {
+          "id": "obs-when",
+          "label": "$observer.when()",
+          "reference": ["observerEvents"],
+          "type": "(key, fn, opts?) => void",
+          "keywords": ["when", "listener", "subscribe"],
+          "text": "Attach a listener to a registered event. Callback signature: (listenerParams, emitParams). Used to hook lifecycle events such as __ready__ from service providers.",
+          "coderef": { "ref": "observer/events/when" }
+        },
+        {
+          "id": "obs-lifecycle",
+          "label": "Lifecycle events",
+          "reference": ["observerEvents"],
+          "keywords": ["__before__", "__initialize__", "__after__", "__boot__", "__ready__", "__exception__", "lifecycle"],
+          "text": "Built-in framework events orchestrate boot: __before__ (DB + auth + routers), __initialize__ / __after__ (router layers), __boot__ (service providers), __ready__ (HTTP server listening), __exception__ (global error handler). Emitted by Handler during the initializing → initialized state machine."
+        }
+      ],
+      "controls": {
+        "right": { "open": true },
+        "header": { "subheader": { "open": false } }
+      }
+    },
+    {
       "keywords": ["general"],
       "id": "general",
       "label": "general",

--- a/src/container/html/web/src/data/versions/v3.5.0.json
+++ b/src/container/html/web/src/data/versions/v3.5.0.json
@@ -520,6 +520,131 @@
       }
     },
     {
+      "keywords": ["observer", "event", "events", "emitter", "event-handler"],
+      "id": "observer",
+      "icon": "local_activity",
+      "label": "Observer",
+      "display": true,
+      "subcats": [
+        { "to": "observer", "label": "Observer" },
+        { "to": "obs-execution", "label": "How events run" },
+        {
+          "to": "observerConfig",
+          "label": "Configuration",
+          "group": ["obs-events", "obs-beforeEmit", "obs-afterEmit", "obs-ObserverConfig"]
+        },
+        {
+          "to": "observerEvents",
+          "label": "Events",
+          "group": ["obs-event-class", "obs-emit", "obs-when", "obs-lifecycle"]
+        }
+      ],
+      "glossary": [
+        {
+          "id": "observer",
+          "label": "Observer",
+          "sublabel": "[./src/package/Observer/index.ts]",
+          "keywords": ["observer", "event bus", "async emitter", "$observer"],
+          "text": "Chasi's built-in async event system. A single Observer instance is created at boot from src/config/observer.ts and exposed as $observer on the Handler and on every Controller (this.$observer). Custom events must be registered in observer.ts before emit() can use them. Event execution runs on the async emitter, isolated from the HTTP request — omit await on emit() in controllers to return a response while the event pipeline still runs."
+        },
+        {
+          "id": "obs-execution",
+          "label": "How events run",
+          "reference": ["observer"],
+          "keywords": ["execution", "async", "fire and forget", "detached", "background", "await"],
+          "text": "Custom events must be listed in src/config/observer.ts events before emit(alias) works. When dispatched, the pipeline (validate → onemit → fire → fireListeners → emitted) runs on AsyncEventEmitter, separate from Express request/response timing. In controllers, this.$observer.emit(...) without await lets res.json() return immediately while the event continues. Use await only when the client must wait. Errors in a detached event do not change an HTTP status already sent."
+        },
+        {
+          "id": "observerConfig",
+          "label": "Observer configuration",
+          "sublabel": "[./src/config/observer.ts]",
+          "reference": ["observer"],
+          "keywords": ["observer config", "ObserverConfig", "observer.ts"],
+          "text": "Typed as ObserverConfig. Maps custom event aliases to class paths under src/, and optionally defines global beforeEmit and afterEmit hooks that wrap every event's fire() unless an event class overrides onemit or emitted."
+        },
+        {
+          "id": "obs-events",
+          "label": "events",
+          "reference": ["observerConfig"],
+          "type": "events",
+          "keywords": ["events registry", "ObserverConfig events", "register event"],
+          "text": "Required registry for custom events. Every alias you pass to emit() must appear here with a class path relative to src/ (no extension). Unlisted aliases are not loaded at boot and will not run. Registered during Observer.setup() on startup — restart after adding new events.",
+          "coderef": { "ref": "observer/config/events" }
+        },
+        {
+          "id": "obs-beforeEmit",
+          "label": "beforeEmit",
+          "reference": ["observerConfig"],
+          "type": "(params) => Promise<void>",
+          "keywords": ["beforeEmit", "global hook", "pre-event"],
+          "text": "Global hook invoked in onemit() immediately before an event's fire() runs. `this` is the Event instance; `params` is the payload from emit(). Skipped for events that define their own onemit/beforeEmit.",
+          "coderef": { "ref": "observer/config/beforeEmit" }
+        },
+        {
+          "id": "obs-afterEmit",
+          "label": "afterEmit",
+          "reference": ["observerConfig"],
+          "type": "(params) => Promise<void>",
+          "keywords": ["afterEmit", "global hook", "post-event"],
+          "text": "Global hook invoked in emitted() after fire() and when() listeners complete. Use for audit logging or metrics. Skipped when the event class defines its own emitted/afterEmit.",
+          "coderef": { "ref": "observer/config/afterEmit" }
+        },
+        {
+          "id": "obs-ObserverConfig",
+          "label": "ObserverConfig",
+          "reference": ["observerConfig"],
+          "type": "ObserverConfig",
+          "keywords": ["ObserverConfig", "observer types", "events type"],
+          "text": "Type exported from package/Observer/index.ts: { events: events; beforeEmit: Function; afterEmit: Function }. The nested events type is Record<string, string> — event alias → src-relative class path."
+        },
+        {
+          "id": "observerEvents",
+          "label": "Events",
+          "sublabel": "[./src/container/events/]",
+          "keywords": ["events", "Event class", "EventInterface", "custom events"],
+          "text": "Custom events are classes extending package/Observer/Event.ts and implementing EventInterface. Each implements validate(params, next) and fire(params). Framework lifecycle events (__before__, __ready__, etc.) live under package/statics/horizon/events/ and are registered internally — not in observer.ts events map."
+        },
+        {
+          "id": "obs-event-class",
+          "label": "Event class",
+          "reference": ["observerEvents"],
+          "type": "EventInterface",
+          "keywords": ["Event", "EventInterface", "Authorize", "container/events"],
+          "text": "Extend Event and implement validate (must call next()) and fire. Listeners from when() run in fireListeners after fire(). Example: src/container/events/Authorize.ts mapped as authorized in observer config.",
+          "coderef": { "ref": "observer/events/eventClass" }
+        },
+        {
+          "id": "obs-emit",
+          "label": "$observer.emit()",
+          "reference": ["observerEvents"],
+          "type": "(event: string, params?: Record<string, unknown>) => Promise<void>",
+          "keywords": ["emit", "dispatch event", "fire event"],
+          "text": "Dispatch a registered event by alias (must exist in observer.ts events). Fire-and-forget in controllers: this.$observer.emit('authorized', payload) without await — response can return while fire() still runs. Block until done: await this.$observer.emit(...). Also on Handler.Instance.$observer and Provider.$observer.",
+          "coderef": { "ref": "observer/events/emit" }
+        },
+        {
+          "id": "obs-when",
+          "label": "$observer.when()",
+          "reference": ["observerEvents"],
+          "type": "(key, fn, opts?) => void",
+          "keywords": ["when", "listener", "subscribe"],
+          "text": "Attach a listener to a registered event. Callback signature: (listenerParams, emitParams). Used to hook lifecycle events such as __ready__ from service providers.",
+          "coderef": { "ref": "observer/events/when" }
+        },
+        {
+          "id": "obs-lifecycle",
+          "label": "Lifecycle events",
+          "reference": ["observerEvents"],
+          "keywords": ["__before__", "__initialize__", "__after__", "__boot__", "__ready__", "__exception__", "lifecycle"],
+          "text": "Built-in framework events orchestrate boot: __before__ (DB + auth + routers), __initialize__ / __after__ (router layers), __boot__ (service providers), __ready__ (HTTP server listening), __exception__ (global error handler). Emitted by Handler during the initializing → initialized state machine."
+        }
+      ],
+      "controls": {
+        "right": { "open": true },
+        "header": { "subheader": { "open": false } }
+      }
+    },
+    {
       "keywords": ["general"],
       "id": "general",
       "label": "general",

--- a/src/container/html/web/src/data/versions/v3.6.0.json
+++ b/src/container/html/web/src/data/versions/v3.6.0.json
@@ -571,6 +571,131 @@
       }
     },
     {
+      "keywords": ["observer", "event", "events", "emitter", "event-handler"],
+      "id": "observer",
+      "icon": "local_activity",
+      "label": "Observer",
+      "display": true,
+      "subcats": [
+        { "to": "observer", "label": "Observer" },
+        { "to": "obs-execution", "label": "How events run" },
+        {
+          "to": "observerConfig",
+          "label": "Configuration",
+          "group": ["obs-events", "obs-beforeEmit", "obs-afterEmit", "obs-ObserverConfig"]
+        },
+        {
+          "to": "observerEvents",
+          "label": "Events",
+          "group": ["obs-event-class", "obs-emit", "obs-when", "obs-lifecycle"]
+        }
+      ],
+      "glossary": [
+        {
+          "id": "observer",
+          "label": "Observer",
+          "sublabel": "[./src/package/Observer/index.ts]",
+          "keywords": ["observer", "event bus", "async emitter", "$observer"],
+          "text": "Chasi's built-in async event system. A single Observer instance is created at boot from src/config/observer.ts and exposed as $observer on the Handler and on every Controller (this.$observer). Custom events must be registered in observer.ts before emit() can use them. Event execution runs on the async emitter, isolated from the HTTP request — omit await on emit() in controllers to return a response while the event pipeline still runs."
+        },
+        {
+          "id": "obs-execution",
+          "label": "How events run",
+          "reference": ["observer"],
+          "keywords": ["execution", "async", "fire and forget", "detached", "background", "await"],
+          "text": "Custom events must be listed in src/config/observer.ts events before emit(alias) works. When dispatched, the pipeline (validate → onemit → fire → fireListeners → emitted) runs on AsyncEventEmitter, separate from Express request/response timing. In controllers, this.$observer.emit(...) without await lets res.json() return immediately while the event continues. Use await only when the client must wait. Errors in a detached event do not change an HTTP status already sent."
+        },
+        {
+          "id": "observerConfig",
+          "label": "Observer configuration",
+          "sublabel": "[./src/config/observer.ts]",
+          "reference": ["observer"],
+          "keywords": ["observer config", "ObserverConfig", "observer.ts"],
+          "text": "Typed as ObserverConfig. Maps custom event aliases to class paths under src/, and optionally defines global beforeEmit and afterEmit hooks that wrap every event's fire() unless an event class overrides onemit or emitted."
+        },
+        {
+          "id": "obs-events",
+          "label": "events",
+          "reference": ["observerConfig"],
+          "type": "events",
+          "keywords": ["events registry", "ObserverConfig events", "register event"],
+          "text": "Required registry for custom events. Every alias you pass to emit() must appear here with a class path relative to src/ (no extension). Unlisted aliases are not loaded at boot and will not run. Registered during Observer.setup() on startup — restart after adding new events.",
+          "coderef": { "ref": "observer/config/events" }
+        },
+        {
+          "id": "obs-beforeEmit",
+          "label": "beforeEmit",
+          "reference": ["observerConfig"],
+          "type": "(params) => Promise<void>",
+          "keywords": ["beforeEmit", "global hook", "pre-event"],
+          "text": "Global hook invoked in onemit() immediately before an event's fire() runs. `this` is the Event instance; `params` is the payload from emit(). Skipped for events that define their own onemit/beforeEmit.",
+          "coderef": { "ref": "observer/config/beforeEmit" }
+        },
+        {
+          "id": "obs-afterEmit",
+          "label": "afterEmit",
+          "reference": ["observerConfig"],
+          "type": "(params) => Promise<void>",
+          "keywords": ["afterEmit", "global hook", "post-event"],
+          "text": "Global hook invoked in emitted() after fire() and when() listeners complete. Use for audit logging or metrics. Skipped when the event class defines its own emitted/afterEmit.",
+          "coderef": { "ref": "observer/config/afterEmit" }
+        },
+        {
+          "id": "obs-ObserverConfig",
+          "label": "ObserverConfig",
+          "reference": ["observerConfig"],
+          "type": "ObserverConfig",
+          "keywords": ["ObserverConfig", "observer types", "events type"],
+          "text": "Type exported from package/Observer/index.ts: { events: events; beforeEmit: Function; afterEmit: Function }. The nested events type is Record<string, string> — event alias → src-relative class path."
+        },
+        {
+          "id": "observerEvents",
+          "label": "Events",
+          "sublabel": "[./src/container/events/]",
+          "keywords": ["events", "Event class", "EventInterface", "custom events"],
+          "text": "Custom events are classes extending package/Observer/Event.ts and implementing EventInterface. Each implements validate(params, next) and fire(params). Framework lifecycle events (__before__, __ready__, etc.) live under package/statics/horizon/events/ and are registered internally — not in observer.ts events map."
+        },
+        {
+          "id": "obs-event-class",
+          "label": "Event class",
+          "reference": ["observerEvents"],
+          "type": "EventInterface",
+          "keywords": ["Event", "EventInterface", "Authorize", "container/events"],
+          "text": "Extend Event and implement validate (must call next()) and fire. Listeners from when() run in fireListeners after fire(). Example: src/container/events/Authorize.ts mapped as authorized in observer config.",
+          "coderef": { "ref": "observer/events/eventClass" }
+        },
+        {
+          "id": "obs-emit",
+          "label": "$observer.emit()",
+          "reference": ["observerEvents"],
+          "type": "(event: string, params?: Record<string, unknown>) => Promise<void>",
+          "keywords": ["emit", "dispatch event", "fire event"],
+          "text": "Dispatch a registered event by alias (must exist in observer.ts events). Fire-and-forget in controllers: this.$observer.emit('authorized', payload) without await — response can return while fire() still runs. Block until done: await this.$observer.emit(...). Also on Handler.Instance.$observer and Provider.$observer.",
+          "coderef": { "ref": "observer/events/emit" }
+        },
+        {
+          "id": "obs-when",
+          "label": "$observer.when()",
+          "reference": ["observerEvents"],
+          "type": "(key, fn, opts?) => void",
+          "keywords": ["when", "listener", "subscribe"],
+          "text": "Attach a listener to a registered event. Callback signature: (listenerParams, emitParams). Used to hook lifecycle events such as __ready__ from service providers.",
+          "coderef": { "ref": "observer/events/when" }
+        },
+        {
+          "id": "obs-lifecycle",
+          "label": "Lifecycle events",
+          "reference": ["observerEvents"],
+          "keywords": ["__before__", "__initialize__", "__after__", "__boot__", "__ready__", "__exception__", "lifecycle"],
+          "text": "Built-in framework events orchestrate boot: __before__ (DB + auth + routers), __initialize__ / __after__ (router layers), __boot__ (service providers), __ready__ (HTTP server listening), __exception__ (global error handler). Emitted by Handler during the initializing → initialized state machine."
+        }
+      ],
+      "controls": {
+        "right": { "open": true },
+        "header": { "subheader": { "open": false } }
+      }
+    },
+    {
       "keywords": ["general"],
       "id": "general",
       "label": "general",

--- a/src/container/html/web/src/pages/main/container.vue
+++ b/src/container/html/web/src/pages/main/container.vue
@@ -22,6 +22,9 @@
       <div v-else-if="ctx.id === 'testing'" class = "bottom-padding">
         <testing />
       </div>
+      <div v-else-if="ctx.id === 'observer'" class = "bottom-padding">
+        <observer />
+      </div>
       <div v-else style="width:100%; height: 100%; ">
         <catcher/>
       </div>
@@ -39,6 +42,7 @@ import controller from "./controller.vue";
 import database from "./database.vue";
 import catcher from "./catcher.vue";
 import testing from "./testing.vue";
+import observer from "./observer.vue";
 import { computed, onMounted } from "vue";
 
 const controlStore = useControlStore()

--- a/src/container/html/web/src/pages/main/observer.vue
+++ b/src/container/html/web/src/pages/main/observer.vue
@@ -1,0 +1,32 @@
+<template>
+  <div>
+    <div class="hero is-small is-dark">
+      <div class="title-container">
+        <div style="display:grid; place-items: center;width: 70px">
+          <span class="material-symbols-rounded is-size-1" style="border:3px solid white; border-radius: 50%;">
+            local_activity
+          </span>
+        </div>
+        <div class="hero-body" style="padding-left: 0px">
+          <p class="title">Observer</p>
+          <p class="subtitle">async <strong>events</strong> across the app lifecycle</p>
+        </div>
+      </div>
+    </div>
+    <div class="content">
+      <observer-what />
+    </div>
+  </div>
+</template>
+
+<script>
+import observerWhat from "@/components/observer/what.vue"
+
+export default {
+  components: {
+    observerWhat,
+  }
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/container/modules/ApiSpecs/spec.ts
+++ b/src/container/modules/ApiSpecs/spec.ts
@@ -1,0 +1,1 @@
+export default class ApiSpec {}

--- a/src/container/services/ApiSpecServiceProvider.ts
+++ b/src/container/services/ApiSpecServiceProvider.ts
@@ -1,0 +1,10 @@
+import { ServiceProviderInterface } from "../../package/framework/Interfaces.js";
+import Provider from "../../package/framework/Services/Provider.js";
+
+export default class ApiSpecServiceProvider extends Provider implements ServiceProviderInterface
+{
+  async boot() {
+  }
+  async beforeServerBoot() {
+  }
+}

--- a/src/package/Observer/Event.ts
+++ b/src/package/Observer/Event.ts
@@ -1,11 +1,21 @@
 import Writer from "./../Logger/types/Writer.js";
 import Listener from "./Listener.js";
 
+/**
+ * Contract for Observer event classes (custom and framework lifecycle events).
+ *
+ * Execution order on `emit()`: `validate` → `onemit` (global `beforeEmit`) →
+ * `fire` → `fireListeners` (`when()` callbacks) → `emitted` (global `afterEmit`).
+ */
 export interface EventInterface {
+  /** Injected global/per-event hooks (`beforeEmit`, `afterEmit`) */
   props: { [key: string]: any };
   logger: Writer;
+  /** Listeners registered via `$observer.when()` */
   listeners: Listener[];
+  /** Gate execution; must call `next()` to proceed to `fire()` */
   validate(a: any, b: Function);
+  /** Main event handler — receives the emit payload */
   fire(a: any): void;
   fireListeners();
   emitted(): void;

--- a/src/package/Observer/index.ts
+++ b/src/package/Observer/index.ts
@@ -4,12 +4,23 @@ import Writer from "../Logger/types/Writer.js";
 import { EventInterface } from "./Event.js";
 import Listener from "./Listener.js";
 
+/**
+ * Shape of `src/config/observer.ts`.
+ *
+ * @property events - Registry of custom application events (see `events` type)
+ * @property beforeEmit - Global hook before each event's `fire()` (unless overridden)
+ * @property afterEmit - Global hook after each event completes (unless overridden)
+ */
 export type ObserverConfig = {
   events: events,
   beforeEmit: Function,
   afterEmit: Function
 }
 
+/**
+ * Event alias → class path relative to `src/` (no extension).
+ * @example `{ authorized: "container/events/Authorize" }`
+ */
 export type events = {
   [key: string]: string
 }
@@ -93,6 +104,14 @@ export default class Observer extends Base {
     ev.listeners.push(lis);
   }
 
+  /**
+   * Dispatch an event by alias. Custom aliases must be registered in `src/config/observer.ts`
+   * (`events` map) and loaded via `setup()` before emit has any effect.
+   *
+   * The handler pipeline runs on the async emitter, decoupled from Express request timing.
+   * Callers that do not `await` this promise (typical in controllers) may already have sent
+   * the HTTP response while `validate` → `fire` → listeners still execute.
+   */
   async emit(event: string, params?: Record<string, unknown>): Promise<void> {
     await this.emitter.emit(event, params);
   }

--- a/test/.env.test
+++ b/test/.env.test
@@ -13,10 +13,9 @@ dbConStringDev=mongodb://localhost:27017/
 dbConStringTest=mongodb://localhost:27017/
 SSLcontainerKey=null
 SSLcontainerCrt=null
-ServerPort=3012
+ServerPort=3013
 oauthkey=chasi
 
-supw=testpass
 ## environment ##
 # please note that [testMode] will not 
 # work on the dev/prod environment.
@@ -29,24 +28,6 @@ devKey=../_security/key.pem
 ## log controls ##
 APP_STATE=1
 DEV_DB="mysql://root:root@localhost:3306/dev"
-PROD_DB="mysql://root:root@localhost:3306/prod"
-ACCOUNTS_DB="mysql://root:root@localhost:3306/accounts"
-ASSETS_DB="mysql://root:root@localhost:3306/assetregister"
-AUS_DB="mysql://root:root@localhost:3306/ausmeter"
-BLDG_DB="mysql://root:root@localhost:3306/bldginfo"
-CM_DB="mysql://root:root@localhost:3306/choicemetering"
-EP_DB="mysql://root:root@localhost:3306/enphase"
-OG_DB="mysql://root:root@localhost:3306/ovationgroup"
-PANA_DB="mysql://root:root@localhost:3306/panasonic"
-SM_DB="mysql://root:root@localhost:3306/securemeter"
-
-ELE_BASEURL=http://localhost:9000/
-## XERO
-xero_client_id=38FA199E8CDC48FCBA3605B8D60FD49E
-xero_client_secret=bIdze5rPJLQlcgyH_G_ppmnlVF3ZctnTJ7h_cNbBoU7PqvFM
-
-o3_xero_client_id=86AB7394325343A2BC38472425261174
-o3_xero_client_secret=7p7PbhmBooJzli6nnYcVkSwUHK7h44XwxjjXAdOYI98OjW4v
 
 ## log controls ##
 Log_History=false

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,14 +1,17 @@
 import { beforeAll, describe } from "vitest";
 import { app } from "./setup.ts";
-
+import routesTest from "./tests/routes.test.ts";
 console.clear();
 describe("App Test running", async () => {
   let $app = new app({
-    basePath: "/baseurl",
+    basePath: "/api",
+    signinUrl: "/api/users/signin",
   });
   beforeAll(async () => {
     // configure app before tests
     // await $app.configure();
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+
   });
 
   /**
@@ -19,5 +22,11 @@ describe("App Test running", async () => {
    * E.G.
    * await User($app);
    * await someTest($app);
+   * 
    */
+
+  await routesTest($app);
+
+  // process.exit(0);
+
 });

--- a/test/tests/routes.test.ts
+++ b/test/tests/routes.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test, beforeAll } from "vitest";
+import { app } from "../setup.ts";
+import App from "../helper.ts";
+console.clear();
+
+const $app = new app({ basePath: "/api/users", signinUrl: "/signin" });
+
+export default async ($app: App) => {
+describe("Route capabilities", async () => {
+  beforeAll(async () => {
+    await $app.send({ url: "/forget", method: "post" });
+  });
+
+  describe("Route resolution", () => {
+    test("unknown route returns 404", async () => {
+      const res = await $app.send({ url: "/nonexistent", method: "get", raw: true });
+      expect(res.statusCode).toBe(404);
+    });
+
+    test("unknown route under /api returns 404", async () => {
+      const res = await $app.send({ url: "/unknown", method: "get" });
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe("POST /signup", () => {
+    test("creates a user and returns 200", async () => {
+      const res = await $app.send({
+        url: "/users/signup",
+        method: "post",
+        logUrl: true,
+        data: { name: "Test User", email: "test@test.com", alias: "testuser", password: "securepass" },
+      });
+      if (res.statusCode !== 200) console.error("[signup 200]", res.statusCode, res.body);
+      expect(res.statusCode).toBe(200);
+    });
+
+    test("returns an error on duplicate email or alias", async () => {
+      const res = await $app.send({
+        url: "/users/signup",
+        method: "post",
+        data: { name: "Test User", email: "test@test.com", alias: "testuser", password: "securepass" },
+      });
+      expect(res.statusCode).not.toBe(200);
+    });
+  });
+
+  describe("POST /signin", () => {
+    test("returns 422 when credentials are missing", async () => {
+      const res = await $app.send({
+        url: "/users/signin",
+        method: "post",
+        data: { email: "test@test.com" },
+      });
+      if (res.statusCode !== 422) console.error("[signin 422]", res.statusCode, res.body);
+      expect(res.statusCode).toBe(422);
+    });
+
+    test("returns 200 with token on valid credentials", async () => {
+      const res = await $app.send({
+        url: "/users/signin",
+        method: "post",
+        data: { email: "test@test.com", pass: "securepass" },
+      });
+      if (res.statusCode !== 200) console.error("[signin 200]", res.statusCode, res.body);
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toHaveProperty("token");
+      expect(res.body).toHaveProperty("user");
+    });
+
+    test("returns an error on wrong password", async () => {
+      const res = await $app.send({
+        url: "/signin",
+        method: "post",
+        data: { email: "test@test.com", pass: "wrongpassword" },
+      });
+      expect(res.statusCode).not.toBe(200);
+    });
+  });
+});
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ import { resolve, dirname } from "node:path";
 export default defineConfig({
   resolve: {},
   test: {
-    exclude: ["dist", "node_modules", "src"],
+    exclude: ["dist", "node_modules", "src", "test/tests"],
     includeSource: ["src/types"],
     globals: true,
     environment: "node",


### PR DESCRIPTION
- Updated version in package.json to 3.6.1.
- Added comprehensive documentation for the Observer event bus in README.md, detailing its configuration, lifecycle, and usage.
- Introduced new Vue components for Observer documentation in the frontend.
- Updated vitest configuration to exclude test directory.
- Disabled Vite compilation in the compiler configuration.
- Enhanced UserController to validate unique email during user creation.
- Added ApiSpecServiceProvider and related files for API specifications.